### PR TITLE
Powertrain class packet a3

### DIFF
--- a/src/AutomatedCar/SystemComponents/IVirtualFunctionBus.cs
+++ b/src/AutomatedCar/SystemComponents/IVirtualFunctionBus.cs
@@ -1,0 +1,16 @@
+﻿using AutomatedCar.SystemComponents.Packets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutomatedCar.SystemComponents
+{
+    public interface IVirtualFunctionBus
+    {
+        void RegisterComponent(SystemComponent component);
+        IReadOnlyDummyPacket DummyPacket { get; set; }
+        IReadOnlyPowertrainComponentPacket PowertrainPacket { get; set; }
+    }
+}

--- a/src/AutomatedCar/SystemComponents/Packets/IReadOnlyPowertrainComponentPacket.cs
+++ b/src/AutomatedCar/SystemComponents/Packets/IReadOnlyPowertrainComponentPacket.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutomatedCar.SystemComponents.Packets
+{
+    public interface IReadOnlyPowertrainComponentPacket
+    {
+        int X { get; }
+        int Y { get; }
+        int Speed { get; }
+        int Rpm { get; }
+        double CarHeadingAngle { get; }
+    }
+}

--- a/src/AutomatedCar/SystemComponents/Packets/PowertrainComponentPacket.cs
+++ b/src/AutomatedCar/SystemComponents/Packets/PowertrainComponentPacket.cs
@@ -1,0 +1,48 @@
+﻿using ReactiveUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutomatedCar.SystemComponents.Packets
+{
+    class PowertrainComponentPacket : ReactiveObject, IReadOnlyPowertrainComponentPacket
+    {
+        private int x;
+        private int y;
+        private int speed;
+        private int rpm;
+        private double carHeadingAngle;
+
+        public int X
+        {
+            get => this.x;
+            set => this.RaiseAndSetIfChanged(ref this.x, value);
+        }
+
+        public int Y
+        {
+            get => this.y;
+            set => this.RaiseAndSetIfChanged(ref this.y, value);
+        }
+
+        public int Speed
+        {
+            get => this.speed;
+            set => this.RaiseAndSetIfChanged(ref this.speed, value);
+        }
+
+        public int Rpm
+        {
+            get => this.rpm;
+            set => this.RaiseAndSetIfChanged(ref this.rpm, value);
+        }
+
+        public double CarHeadingAngle
+        {
+            get => this.carHeadingAngle;
+            set => this.RaiseAndSetIfChanged(ref this.carHeadingAngle, value);
+        }
+    }
+}

--- a/src/AutomatedCar/SystemComponents/Powertrain/Powertrain.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/Powertrain.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutomatedCar.SystemComponents.Powertrain
+{
+    public class Powertrain : SystemComponent
+    {
+        public Powertrain(VirtualFunctionBus virtualFunctionBus)
+           : base(virtualFunctionBus)
+        {
+            
+        }
+        public override void Process()
+        {
+            
+        }
+    }
+}

--- a/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
@@ -8,7 +8,7 @@ namespace AutomatedCar.SystemComponents.Powertrain
 {
     public class PowertrainComponent : SystemComponent
     {
-        public PowertrainComponent(VirtualFunctionBus virtualFunctionBus)
+        public PowertrainComponent(IVirtualFunctionBus virtualFunctionBus)
            : base(virtualFunctionBus)
         {
             

--- a/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AutomatedCar.SystemComponents.Packets;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,10 +9,12 @@ namespace AutomatedCar.SystemComponents.Powertrain
 {
     public class PowertrainComponent : SystemComponent
     {
+        private PowertrainComponentPacket powertrainPacket;
         public PowertrainComponent(IVirtualFunctionBus virtualFunctionBus)
            : base(virtualFunctionBus)
         {
-            
+            this.powertrainPacket = new PowertrainComponentPacket();
+            virtualFunctionBus.PowertrainPacket = this.powertrainPacket;
         }
         public override void Process()
         {

--- a/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace AutomatedCar.SystemComponents.Powertrain
 {
-    public class Powertrain : SystemComponent
+    public class PowertrainComponent : SystemComponent
     {
-        public Powertrain(VirtualFunctionBus virtualFunctionBus)
+        public PowertrainComponent(VirtualFunctionBus virtualFunctionBus)
            : base(virtualFunctionBus)
         {
             

--- a/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
@@ -18,7 +18,6 @@ namespace AutomatedCar.SystemComponents.Powertrain
         }
         public override void Process()
         {
-            
         }
     }
 }

--- a/src/AutomatedCar/SystemComponents/SystemComponent.cs
+++ b/src/AutomatedCar/SystemComponents/SystemComponent.cs
@@ -2,9 +2,9 @@ namespace AutomatedCar.SystemComponents
 {
     public abstract class SystemComponent
     {
-        protected VirtualFunctionBus virtualFunctionBus;
+        protected IVirtualFunctionBus virtualFunctionBus;
 
-        protected SystemComponent(VirtualFunctionBus virtualFunctionBus)
+        protected SystemComponent(IVirtualFunctionBus virtualFunctionBus)
         {
             this.virtualFunctionBus = virtualFunctionBus;
             virtualFunctionBus.RegisterComponent(this);

--- a/src/AutomatedCar/SystemComponents/VirtualFunctionBus.cs
+++ b/src/AutomatedCar/SystemComponents/VirtualFunctionBus.cs
@@ -3,8 +3,9 @@ namespace AutomatedCar.SystemComponents
     using System.Collections.Generic;
     using System.Windows.Threading;
     using System;
+    using AutomatedCar.SystemComponents.Packets;
 
-    public class VirtualFunctionBus
+    public class VirtualFunctionBus : IVirtualFunctionBus
     {
         private List<SystemComponent> components = new List<SystemComponent>();
 

--- a/src/AutomatedCar/SystemComponents/VirtualFunctionBus.cs
+++ b/src/AutomatedCar/SystemComponents/VirtualFunctionBus.cs
@@ -10,6 +10,7 @@ namespace AutomatedCar.SystemComponents
         private List<SystemComponent> components = new List<SystemComponent>();
 
         public IReadOnlyDummyPacket DummyPacket { get; set; }
+        public IReadOnlyPowertrainComponentPacket PowertrainPacket { get; set; }
 
         private DispatcherTimer timer = new DispatcherTimer();
 

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/PowertrainComponentTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/PowertrainComponentTests.cs
@@ -20,5 +20,14 @@ namespace Test.SystemComponents.Powertrain
 
             mockBus.Verify(m => m.RegisterComponent(ptr), Times.Once);
         }
+
+        [Fact]
+        public void VFBGetsPowertrainPacketAfterCreatingPowertrainComponent()
+        {
+            VirtualFunctionBus virtualFunctionBus = new VirtualFunctionBus();
+            PowertrainComponent powertrain = new PowertrainComponent(virtualFunctionBus);
+
+            Assert.True(virtualFunctionBus.PowertrainPacket != null);
+        }
     }
 }

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/PowertrainComponentTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/PowertrainComponentTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutomatedCar.SystemComponents.Powertrain;
+using AutomatedCar.SystemComponents;
+using Moq;
+using Xunit;
+
+namespace Test.SystemComponents.Powertrain
+{
+    public class PowertrainComponentTests
+    {
+        [Fact]
+        public  void PowertrainAutomaticallyGetsRegisteredToVFB()
+        {
+            Mock<IVirtualFunctionBus> mockBus = new Mock<IVirtualFunctionBus>();
+            PowertrainComponent ptr = new PowertrainComponent(mockBus.Object);
+
+            mockBus.Verify(m => m.RegisterComponent(ptr), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Megvalósításra került: PowertrainComponent osztály elkészítése, ami regisztrálja magát komponensként a VirtualFunctionBus-ra. A Powertrain-hez tartozó packet osztály és annak read-only interfészének elkészítése. Teszt írása a regisztrálás ellenőrzésére és a powertrain read-only packet létrejöttére a VirtualFunctionBus-on belül.

A skeletonban csináltam egy kis változtatást, remélem ez így egy elfogadható megoldás:
A regisztrálás teszteléséhez készítettem egy IVirtualFunctionBus interfészt amit a VFB megvalósít, mert másképp nem sikerült megoldanom a tesztet a privát komponens lista miatt, illetve, mert nem szerettem volna osztály mockolni + osztály mockolása esetén át kellett volna írni a VFB, RegisterComponent() metódusát virtual-ra.
A többi csapattól annyi erőfeszítést igényelne ez az interfészes megvalósítás, hogy a Read-only packeteket hozzá kéne adni az interfészhez property-ként. Ezek mellett viszont nagyon triviálissá teszi az interfész a komponensek regisztrációjának tesztelését.