### PR TITLE
A1 sprint1 input handling

### DIFF
--- a/src/AutomatedCar/KeyboardHandling/HoldableKey.cs
+++ b/src/AutomatedCar/KeyboardHandling/HoldableKey.cs
@@ -10,7 +10,6 @@ namespace AutomatedCar.KeyboardHandling
         public Action<double> OnHold { get; }
         public Action<double> OnIdle { get; }
 
-        public double CurrentStateDuration { get; set; }
         public bool IsBeingHeld { get; set; }
 
         public HoldableKey(Key key, Action<double> onHold, Action<double> onIdle)

--- a/src/AutomatedCar/KeyboardHandling/HoldableKey.cs
+++ b/src/AutomatedCar/KeyboardHandling/HoldableKey.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace AutomatedCar.KeyboardHandling
+{
+    public class HoldableKey
+    {
+        public Key Key { get; }
+
+        public Action<double> OnHold { get; }
+        public Action<double> OnIdle { get; }
+
+        public double CurrentStateDuration { get; set; }
+        public bool IsBeingHeld { get; set; }
+
+        public HoldableKey(Key key, Action<double> onHold, Action<double> onIdle)
+        {
+            this.Key = key;
+            this.OnHold = onHold;
+            this.OnIdle = onIdle;
+        }
+    }
+}

--- a/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
+++ b/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
@@ -17,17 +17,44 @@ namespace AutomatedCar.KeyboardHandling
 
         public void OnKeyDown(Key key)
         {
+            foreach (PressableKey pressableKey in PressableKeys)
+            {
+                if (key == pressableKey.Key)
+                {
+                    pressableKey.OnPress();
+                }
+            }
 
+            foreach (HoldableKey holdableKey in HoldableKeys)
+            {
+                if (key == holdableKey.Key)
+                {
+                    holdableKey.CurrentStateDuration = 0;
+                    holdableKey.IsBeingHeld = true;
+                }
+            }
         }
 
         public void OnKeyUp(Key key)
         {
-
+            foreach (HoldableKey holdableKey in HoldableKeys)
+            {
+                if (key == holdableKey.Key)
+                {
+                    holdableKey.IsBeingHeld = false;
+                    holdableKey.CurrentStateDuration = 0;
+                }
+            }
         }
 
         public void Tick()
         {
-
+            foreach (HoldableKey holdableKey in HoldableKeys)
+            {
+                holdableKey.CurrentStateDuration += tickInterval / 1000;
+                if (holdableKey.IsBeingHeld) holdableKey.OnHold(holdableKey.CurrentStateDuration);
+                else holdableKey.OnIdle(holdableKey.CurrentStateDuration);
+            }
         }
     }
 }

--- a/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
+++ b/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
@@ -17,33 +17,22 @@ namespace AutomatedCar.KeyboardHandling
 
         public void OnKeyDown(Key key)
         {
-            foreach (PressableKey pressableKey in PressableKeys)
+            PressableKeys.Find(pressableKey => pressableKey.Key == key)?.OnPress();
+            HoldableKey holdableKey = HoldableKeys.Find(holdableKey => holdableKey.Key == key);
+            if (holdableKey != null)
             {
-                if (key == pressableKey.Key)
-                {
-                    pressableKey.OnPress();
-                }
-            }
-
-            foreach (HoldableKey holdableKey in HoldableKeys)
-            {
-                if (key == holdableKey.Key)
-                {
-                    holdableKey.CurrentStateDuration = 0;
-                    holdableKey.IsBeingHeld = true;
-                }
+                holdableKey.CurrentStateDuration = 0;
+                holdableKey.IsBeingHeld = true;
             }
         }
 
         public void OnKeyUp(Key key)
         {
-            foreach (HoldableKey holdableKey in HoldableKeys)
+            HoldableKey holdableKey = HoldableKeys.Find(holdableKey => holdableKey.Key == key);
+            if (holdableKey != null)
             {
-                if (key == holdableKey.Key)
-                {
-                    holdableKey.IsBeingHeld = false;
-                    holdableKey.CurrentStateDuration = 0;
-                }
+                holdableKey.IsBeingHeld = false;
+                holdableKey.CurrentStateDuration = 0;
             }
         }
 

--- a/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
+++ b/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
@@ -41,8 +41,8 @@ namespace AutomatedCar.KeyboardHandling
             foreach (HoldableKey holdableKey in HoldableKeys)
             {
                 holdableKey.CurrentStateDuration += tickInterval / 1000;
-                if (holdableKey.IsBeingHeld) holdableKey.OnHold(holdableKey.CurrentStateDuration);
-                else holdableKey.OnIdle(holdableKey.CurrentStateDuration);
+                if (holdableKey.IsBeingHeld && holdableKey.OnHold != null) holdableKey.OnHold(holdableKey.CurrentStateDuration);
+                else if (holdableKey.OnIdle != null) holdableKey.OnIdle(holdableKey.CurrentStateDuration);
             }
         }
     }

--- a/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
+++ b/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Windows.Input;
+
+namespace AutomatedCar.KeyboardHandling
+{
+    public class KeyboardHandler
+    {
+        public List<PressableKey> PressableKeys { get; } = new List<PressableKey>();
+        public List<HoldableKey> HoldableKeys { get; } = new List<HoldableKey>();
+
+        private double tickInterval;
+
+        public KeyboardHandler(double tickInterval)
+        {
+            this.tickInterval = tickInterval;
+        }
+
+        public void OnKeyDown(Key key)
+        {
+
+        }
+
+        public void OnKeyUp(Key key)
+        {
+
+        }
+
+        public void Tick()
+        {
+
+        }
+    }
+}

--- a/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
+++ b/src/AutomatedCar/KeyboardHandling/KeyboardHandler.cs
@@ -21,7 +21,6 @@ namespace AutomatedCar.KeyboardHandling
             HoldableKey holdableKey = HoldableKeys.Find(holdableKey => holdableKey.Key == key);
             if (holdableKey != null)
             {
-                holdableKey.CurrentStateDuration = 0;
                 holdableKey.IsBeingHeld = true;
             }
         }
@@ -32,7 +31,6 @@ namespace AutomatedCar.KeyboardHandling
             if (holdableKey != null)
             {
                 holdableKey.IsBeingHeld = false;
-                holdableKey.CurrentStateDuration = 0;
             }
         }
 
@@ -40,9 +38,8 @@ namespace AutomatedCar.KeyboardHandling
         {
             foreach (HoldableKey holdableKey in HoldableKeys)
             {
-                holdableKey.CurrentStateDuration += tickInterval / 1000;
-                if (holdableKey.IsBeingHeld && holdableKey.OnHold != null) holdableKey.OnHold(holdableKey.CurrentStateDuration);
-                else if (holdableKey.OnIdle != null) holdableKey.OnIdle(holdableKey.CurrentStateDuration);
+                if (holdableKey.IsBeingHeld && holdableKey.OnHold != null) holdableKey.OnHold(tickInterval / 1000);
+                else if (holdableKey.OnIdle != null) holdableKey.OnIdle(tickInterval / 1000);
             }
         }
     }

--- a/src/AutomatedCar/KeyboardHandling/PressableKey.cs
+++ b/src/AutomatedCar/KeyboardHandling/PressableKey.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace AutomatedCar.KeyboardHandling
+{
+    public class PressableKey
+    {
+        public Key Key { get; }
+
+        public Action OnPress { get; }
+
+        public PressableKey(Key key, Action onPress)
+        {
+            this.Key = key;
+            this.OnPress = onPress;
+        }
+    }
+}

--- a/src/AutomatedCar/MainWindow.xaml.cs
+++ b/src/AutomatedCar/MainWindow.xaml.cs
@@ -31,6 +31,8 @@ namespace AutomatedCar
     /// </summary>
     public partial class MainWindow : Window
     {
+        private readonly double tickInterval = 20;
+
         public MainWindowViewModel ViewModel { get; set; }
         DispatcherTimer timer = new DispatcherTimer();
         World world = World.Instance;
@@ -41,7 +43,7 @@ namespace AutomatedCar
             ViewModel = new MainWindowViewModel(world);
             InitializeComponent();
 
-            timer.Interval = TimeSpan.FromMilliseconds(20);
+            timer.Interval = TimeSpan.FromMilliseconds(tickInterval);
             timer.Tick += logic;
             timer.Start();
             // make my dockpanel focus of this game

--- a/src/AutomatedCar/MainWindow.xaml.cs
+++ b/src/AutomatedCar/MainWindow.xaml.cs
@@ -23,6 +23,7 @@ using AutomatedCar.Models;
 using AutomatedCar.ViewModels;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
+using AutomatedCar.KeyboardHandling;
 
 namespace AutomatedCar
 {
@@ -36,12 +37,19 @@ namespace AutomatedCar
         public MainWindowViewModel ViewModel { get; set; }
         DispatcherTimer timer = new DispatcherTimer();
         World world = World.Instance;
-        bool moveLeft, moveRight, moveUp, moveDown;
-        
+
+        private KeyboardHandler keyboardHandler;
+
         public MainWindow()
         {
             ViewModel = new MainWindowViewModel(world);
             InitializeComponent();
+
+            keyboardHandler = new KeyboardHandler(tickInterval);
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Left, (duration) => World.Instance.ControlledCar.X -= 5, null));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Right, (duration) => World.Instance.ControlledCar.X += 5, null));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Up, (duration) => World.Instance.ControlledCar.Y -= 5, null));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Down, (duration) => World.Instance.ControlledCar.Y += 5, null));
 
             timer.Interval = TimeSpan.FromMilliseconds(tickInterval);
             timer.Tick += logic;
@@ -49,7 +57,7 @@ namespace AutomatedCar
             // make my dockpanel focus of this game
             MainDockPanel.Focus();
 
- 
+
             world.Width = 2000;
             world.Height = 1000;
 
@@ -83,61 +91,16 @@ namespace AutomatedCar
 
         private void onKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Left)
-            {
-                moveLeft = true;
-            }
-            if (e.Key == Key.Right)
-            {
-                moveRight = true;
-            }
-             if (e.Key == Key.Up)
-            {
-                moveUp = true;
-            }
-            if (e.Key == Key.Down)
-            {
-                moveDown = true;
-            }
+            keyboardHandler.OnKeyDown(e.Key);
         }
         private void onKeyUp(object sender, KeyEventArgs e)
         {
-             if (e.Key == Key.Left)
-            {
-                moveLeft = false;
-            }
-            if (e.Key == Key.Right)
-            {
-                moveRight = false;
-            }
-            if (e.Key == Key.Up)
-            {
-                moveUp = false;
-            }
-            if (e.Key == Key.Down)
-            {
-                moveDown = false;
-            }
+            keyboardHandler.OnKeyUp(e.Key);
         }
 
         private void logic(object sender, EventArgs e)
         {
-            if (moveLeft)
-            {
-                World.Instance.ControlledCar.X -= 5;
-            }
-            if (moveRight)
-            {
-                World.Instance.ControlledCar.X += 5;
-            }
-            if (moveUp)
-            {
-                World.Instance.ControlledCar.Y -= 5;
-            }
-            if (moveDown)
-            {
-                World.Instance.ControlledCar.Y += 5;
-            }
+            keyboardHandler.Tick();
         }
 
     }

--- a/test/AutomatedCarTest/KeyboardHandler/KeyboardHandlerTest.cs
+++ b/test/AutomatedCarTest/KeyboardHandler/KeyboardHandlerTest.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+
+namespace AutomatedCarTest.KeyboardHandler
+{
+    public class KeyboardHandlerTest
+    {
+        [Test]
+        public void PressableKeyOnPressEventIsCalledCorrectlyFromKeyboardHandler()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyOnHoldEventIsCalledAfterEveryTickFromKeyboardHandlerIfKeyIsPressedAndNotReleased()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyOnIdleEventIsCalledAfterEveryTickFromKeyboardHandlerIfKeyIsNotPressed()
+        {
+
+        }
+
+        [Test]
+        public void CanHoldDownMultipleKeys()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyDurationIsCorrectAfterSeveralTicksWhenHolding()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyDurationIsCorrectAfterSeveralTicksWhenIdle()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyDurationResetsAfterStateChange()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyStateChangesOnPress()
+        {
+
+        }
+
+        [Test]
+        public void HoldableKeyStateChangesOnRelease()
+        {
+
+        }
+    }
+}

--- a/test/AutomatedCarTest/KeyboardHandling/KeyboardHandlerTest.cs
+++ b/test/AutomatedCarTest/KeyboardHandling/KeyboardHandlerTest.cs
@@ -1,13 +1,13 @@
 ﻿using NUnit.Framework;
 
-namespace AutomatedCarTest.KeyboardHandler
+namespace AutomatedCarTest.KeyboardHandling
 {
     public class KeyboardHandlerTest
     {
         [Test]
         public void PressableKeyOnPressEventIsCalledCorrectlyFromKeyboardHandler()
         {
-
+            
         }
 
         [Test]
@@ -47,13 +47,13 @@ namespace AutomatedCarTest.KeyboardHandler
         }
 
         [Test]
-        public void HoldableKeyStateChangesOnPress()
+        public void HoldableKeyIsBeingHeldAfterPress()
         {
 
         }
 
         [Test]
-        public void HoldableKeyStateChangesOnRelease()
+        public void HoldableKeyIsNotBeingHeldAfterRelease()
         {
 
         }

--- a/test/AutomatedCarTest/KeyboardHandling/KeyboardHandlerTest.cs
+++ b/test/AutomatedCarTest/KeyboardHandling/KeyboardHandlerTest.cs
@@ -10,7 +10,7 @@ namespace AutomatedCarTest.KeyboardHandling
         private KeyboardHandler keyboardHandler;
         private int testInt1;
         private int testInt2;
-        private int testInt3;
+        private double testDouble;
 
         [SetUp]
         public void SetUp()
@@ -21,7 +21,7 @@ namespace AutomatedCarTest.KeyboardHandling
             PressableKey key2 = new PressableKey(Key.D, () => testInt1--);
 
             HoldableKey key3 = new HoldableKey(Key.Q, (x) => testInt2 += 2, (x) => testInt2 -= 2);
-            HoldableKey key4 = new HoldableKey(Key.E, (x) => testInt3 += 4, (x) => testInt3 -= 4);
+            HoldableKey key4 = new HoldableKey(Key.E, (x) => testDouble += x, (x) => testDouble -= x);
 
             keyboardHandler.PressableKeys.Add(key1);
             keyboardHandler.PressableKeys.Add(key2);
@@ -58,12 +58,12 @@ namespace AutomatedCarTest.KeyboardHandling
         [Test]
         public void HoldableKeyOnIdleEventIsCalledAfterEveryTickFromKeyboardHandlerIfKeyIsNotPressed()
         {
-            testInt3 = 0;
+            testDouble = 0;
             keyboardHandler.Tick();
             keyboardHandler.Tick();
             keyboardHandler.Tick();
 
-            Assert.That(testInt3, Is.EqualTo(-12));
+            Assert.That(testDouble, Is.LessThan(-0.02));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace AutomatedCarTest.KeyboardHandling
         {
             testInt1 = 0;
             testInt2 = 0;
-            testInt3 = 0;
+            testDouble = 0;
             keyboardHandler.OnKeyDown(Key.A);
             keyboardHandler.OnKeyDown(Key.D);
             keyboardHandler.OnKeyDown(Key.Q);
@@ -80,41 +80,18 @@ namespace AutomatedCarTest.KeyboardHandling
             keyboardHandler.Tick();
 
             Assert.That(testInt1, Is.EqualTo(0));
-            Assert.That(testInt2, Is.EqualTo(4));
-            Assert.That(testInt3, Is.EqualTo(8));
+            Assert.That(testInt2, Is.GreaterThan(0));
+            Assert.That(testDouble, Is.GreaterThan(0));
         }
 
         [Test]
-        public void HoldableKeyDurationIsCorrectAfterSeveralTicksWhenHolding()
+        public void HoldableKeyTickDurationIsCorrectWhenHolding()
         {
-            keyboardHandler.OnKeyDown(Key.Q);
-            keyboardHandler.Tick();
-            keyboardHandler.Tick();
-            keyboardHandler.Tick();
-
-            Assert.That(keyboardHandler.HoldableKeys[0].CurrentStateDuration, Is.EqualTo(0.06));
-        }
-
-        [Test]
-        public void HoldableKeyDurationIsCorrectAfterSeveralTicksWhenIdle()
-        {
-            keyboardHandler.Tick();
-            keyboardHandler.Tick();
-            keyboardHandler.Tick();
+            testDouble = 0;
+            keyboardHandler.OnKeyDown(Key.E);
             keyboardHandler.Tick();
 
-            Assert.That(keyboardHandler.HoldableKeys[1].CurrentStateDuration, Is.EqualTo(0.08));
-        }
-
-        [Test]
-        public void HoldableKeyDurationResetsAfterStateChange()
-        {
-            keyboardHandler.OnKeyDown(Key.Q);
-            keyboardHandler.Tick();
-            keyboardHandler.Tick();
-            keyboardHandler.OnKeyUp(Key.Q);
-
-            Assert.That(keyboardHandler.HoldableKeys[0].CurrentStateDuration, Is.EqualTo(0));
+            Assert.That(testDouble, Is.EqualTo(0.02));
         }
 
         [Test]

--- a/test/AutomatedCarTest/KeyboardHandling/KeyboardHandlerTest.cs
+++ b/test/AutomatedCarTest/KeyboardHandling/KeyboardHandlerTest.cs
@@ -1,61 +1,137 @@
-﻿using NUnit.Framework;
+﻿using AutomatedCar.KeyboardHandling;
+using NUnit.Framework;
+using System;
+using System.Windows.Input;
 
 namespace AutomatedCarTest.KeyboardHandling
 {
     public class KeyboardHandlerTest
     {
+        private KeyboardHandler keyboardHandler;
+        private int testInt1;
+        private int testInt2;
+        private int testInt3;
+
+        [SetUp]
+        public void SetUp()
+        {
+            keyboardHandler = new KeyboardHandler(20);
+
+            PressableKey key1 = new PressableKey(Key.A, () => testInt1++);
+            PressableKey key2 = new PressableKey(Key.D, () => testInt1--);
+
+            HoldableKey key3 = new HoldableKey(Key.Q, (x) => testInt2 += 2, (x) => testInt2 -= 2);
+            HoldableKey key4 = new HoldableKey(Key.E, (x) => testInt3 += 4, (x) => testInt3 -= 4);
+
+            keyboardHandler.PressableKeys.Add(key1);
+            keyboardHandler.PressableKeys.Add(key2);
+
+            keyboardHandler.HoldableKeys.Add(key3);
+            keyboardHandler.HoldableKeys.Add(key4);
+        }
+
         [Test]
         public void PressableKeyOnPressEventIsCalledCorrectlyFromKeyboardHandler()
         {
-            
+            testInt1 = 0;
+            keyboardHandler.OnKeyDown(Key.A);
+            keyboardHandler.OnKeyDown(Key.D);
+            keyboardHandler.OnKeyDown(Key.A);
+
+            Assert.That(testInt1, Is.EqualTo(1));
         }
 
         [Test]
         public void HoldableKeyOnHoldEventIsCalledAfterEveryTickFromKeyboardHandlerIfKeyIsPressedAndNotReleased()
         {
+            testInt2 = 0;
+            keyboardHandler.OnKeyDown(Key.Q);
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
 
+            Assert.That(testInt2, Is.EqualTo(10));
         }
 
         [Test]
         public void HoldableKeyOnIdleEventIsCalledAfterEveryTickFromKeyboardHandlerIfKeyIsNotPressed()
         {
+            testInt3 = 0;
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
 
+            Assert.That(testInt3, Is.EqualTo(-12));
         }
 
         [Test]
         public void CanHoldDownMultipleKeys()
         {
+            testInt1 = 0;
+            testInt2 = 0;
+            testInt3 = 0;
+            keyboardHandler.OnKeyDown(Key.A);
+            keyboardHandler.OnKeyDown(Key.D);
+            keyboardHandler.OnKeyDown(Key.Q);
+            keyboardHandler.OnKeyDown(Key.E);
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
 
+            Assert.That(testInt1, Is.EqualTo(0));
+            Assert.That(testInt2, Is.EqualTo(4));
+            Assert.That(testInt3, Is.EqualTo(8));
         }
 
         [Test]
         public void HoldableKeyDurationIsCorrectAfterSeveralTicksWhenHolding()
         {
+            keyboardHandler.OnKeyDown(Key.Q);
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
 
+            Assert.That(keyboardHandler.HoldableKeys[0].CurrentStateDuration, Is.EqualTo(0.06));
         }
 
         [Test]
         public void HoldableKeyDurationIsCorrectAfterSeveralTicksWhenIdle()
         {
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
 
+            Assert.That(keyboardHandler.HoldableKeys[1].CurrentStateDuration, Is.EqualTo(0.08));
         }
 
         [Test]
         public void HoldableKeyDurationResetsAfterStateChange()
         {
+            keyboardHandler.OnKeyDown(Key.Q);
+            keyboardHandler.Tick();
+            keyboardHandler.Tick();
+            keyboardHandler.OnKeyUp(Key.Q);
 
+            Assert.That(keyboardHandler.HoldableKeys[0].CurrentStateDuration, Is.EqualTo(0));
         }
 
         [Test]
         public void HoldableKeyIsBeingHeldAfterPress()
         {
+            keyboardHandler.OnKeyDown(Key.Q);
 
+            Assert.That(keyboardHandler.HoldableKeys[0].IsBeingHeld, Is.True);
         }
 
         [Test]
         public void HoldableKeyIsNotBeingHeldAfterRelease()
         {
+            keyboardHandler.OnKeyDown(Key.Q);
+            keyboardHandler.OnKeyUp(Key.Q);
 
+            Assert.That(keyboardHandler.HoldableKeys[0].IsBeingHeld, Is.False);
         }
     }
 }


### PR DESCRIPTION
Task #33 
https://github.com/SzFMV2021-Tavasz/AutomatedCar-A/issues/1#issuecomment-785807887 és a [referencia architektúra](https://szfmv2021-tavasz.github.io/handout/reference_architecture.html) alapján oldottam meg a feladatot. Pár dolgot máshogy kellett/volt célszerű implementálni, mint ahogy a [diagramon](https://user-images.githubusercontent.com/60270473/109143374-413cc700-7760-11eb-9baa-4c3a8c97c822.png) látszik:
- Ez maga a Keyboard Handler, ami teljesen leválasztható a Dashboard-ról, mint ahogy [ez az ábra](https://szfmv2021-tavasz.github.io/handout/images/full_software.png) is szemlélteti
- Key-nek nem kell Tick, mivel az események attól függetlenül hívódnak meg
- A HoldableKey-nek onClickEvent-re igazából nincs szüksége, ezért nem láttam értelmét leszármaztatni a Key-ből (úgy is meg lehetett volna oldani a feladatot, de szerintem így tisztább a kód)
- A duration eltárolása helyett a HoldableKey eseményei bementként megkapják az előző Tick óta eltelt időt másodpercben, double típusként (így szerintem sokkal könnyebb megoldani a fokozatos növelés/csökkentés problémáját)
- Az elnevezések is kicsit másak, ütközés vagy konzisztencia miatt

Ezeket csak azért soroltam fel, hogy le legyenek dokumentálva a változtatások, de amúgy nagyon sokat segített a diagram. 🙂

Ezek alapján remélhetőleg már könnyen megvalósítható a fokozatos növelés/csökkentés is. Pl:
```C#
HoldableKey forwardKey = new HoldableKey(Key.Up,
    (tickDurationInSec) => car.SpeedPercentage = Math.Min(car.SpeedPercentage + (tickDurationInSec * 100), 100), // hold event
    (tickDurationInSec) => car.SpeedPercentage = Math.Max(car.SpeedPercentage - (tickDurationInSec * 100), 0)); // idle event
keyboardHandler.HoldableKeys.Add(forwardKey);
```