### PR TITLE
Vonóerő és fékezési erő

### DIFF
--- a/src/AutomatedCar/SystemComponents/Powertrain/IVehicleConstants.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/IVehicleConstants.cs
@@ -63,7 +63,7 @@ namespace AutomatedCar.SystemComponents.Powertrain
         float CrossSectionalArea { get; }
 
         /// <summary>
-        /// Constant used when calculating the braking force; kilograms.
+        /// Constant used when calculating the braking force; kilogram over meters.
         /// </summary>
         float BrakingConstant { get; }
 

--- a/src/AutomatedCar/SystemComponents/Powertrain/IVehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/IVehicleForces.cs
@@ -1,0 +1,11 @@
+﻿using System.Numerics;
+
+namespace AutomatedCar.SystemComponents.Powertrain
+{
+    public interface IVehicleForces
+    {
+        Vector2 GetDragForce(Vector2 velocity);
+        Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, int gearIdx);
+        Vector2 GetTractiveForceInReverse(float gasPedal, Vector2 wheelDirection);
+    }
+}

--- a/src/AutomatedCar/SystemComponents/Powertrain/IVehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/IVehicleForces.cs
@@ -7,5 +7,6 @@ namespace AutomatedCar.SystemComponents.Powertrain
         Vector2 GetDragForce(Vector2 velocity);
         Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, int gearIdx);
         Vector2 GetTractiveForceInReverse(float gasPedal, Vector2 wheelDirection);
+        Vector2 GetBrakingForce(float brakePedal, Vector2 currentVelocity);
     }
 }

--- a/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
@@ -34,5 +34,35 @@ namespace AutomatedCar.SystemComponents.Powertrain
 
             return 0.5f * vehicleConstants.AirDensity * velocitySquared * dragArea * forceDir;
         }
+
+        public Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, bool isReverse, int? gearIdx)
+        {
+            if(!isReverse && gearIdx == null)
+            {
+                throw new ArgumentException($"{nameof(gearIdx)} can't be null when {nameof(isReverse)} is false", nameof(gearIdx));
+            }
+
+            if(gearIdx != null && gearIdx >= vehicleConstants.NumberOfGears)
+            {
+                throw new ArgumentException("Gear index is out of bounds.", nameof(gearIdx));
+            }
+
+            float gearRatio;
+            if(!isReverse)
+            {
+                gearRatio = vehicleConstants.GearRatios[gearIdx.Value];
+            }
+            else
+            {
+                gearRatio = -vehicleConstants.ReverseGearRatio;
+            }
+
+            var engineTorque = vehicleConstants.GetEngineTorque(vehicleConstants.GetCrankshaftSpeed(gasPedal));
+            var differentialRatio = vehicleConstants.DifferentialRatio;
+            var transmissionEfficiency = vehicleConstants.TransmissionEfficiency;
+            var wheelRadius = vehicleConstants.OverallWheelRadius;
+
+            return wheelDirection * engineTorque * gearRatio * differentialRatio * transmissionEfficiency / wheelRadius;
+        }
     }
 }

--- a/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
@@ -12,11 +12,6 @@ namespace AutomatedCar.SystemComponents.Powertrain
             this.vehicleConstants = vehicleConstants;
         }
 
-        /// <summary>
-        /// Calculates the drag force acting on a particle.
-        /// </summary>
-        /// <param name="velocity">Speed of the particle.</param>
-        /// <returns>Drag force.</returns>
         public Vector2 GetDragForce(Vector2 velocity)
         {
             var relativeVelocity = Vector2.Zero - velocity;
@@ -35,28 +30,25 @@ namespace AutomatedCar.SystemComponents.Powertrain
             return 0.5f * vehicleConstants.AirDensity * velocitySquared * dragArea * forceDir;
         }
 
-        public Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, bool isReverse, int? gearIdx)
+        public Vector2 GetTractiveForceInReverse(float gasPedal, Vector2 wheelDirection)
         {
-            if(!isReverse && gearIdx == null)
-            {
-                throw new ArgumentException($"{nameof(gearIdx)} can't be null when {nameof(isReverse)} is false", nameof(gearIdx));
-            }
+            var gearRatio = -vehicleConstants.ReverseGearRatio;
+            return CalculateTractiveForce(gasPedal, wheelDirection, gearRatio);
+        }
 
-            if(gearIdx != null && gearIdx >= vehicleConstants.NumberOfGears)
+        public Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, int gearIdx)
+        {
+            if(gearIdx < 0 || vehicleConstants.NumberOfGears <= gearIdx)
             {
                 throw new ArgumentException("Gear index is out of bounds.", nameof(gearIdx));
             }
 
-            float gearRatio;
-            if(!isReverse)
-            {
-                gearRatio = vehicleConstants.GearRatios[gearIdx.Value];
-            }
-            else
-            {
-                gearRatio = -vehicleConstants.ReverseGearRatio;
-            }
+            var gearRatio = vehicleConstants.GearRatios[gearIdx];
+            return CalculateTractiveForce(gasPedal, wheelDirection, gearRatio);
+        }
 
+        private Vector2 CalculateTractiveForce(float gasPedal, Vector2 wheelDirection, float gearRatio)
+        {
             var engineTorque = vehicleConstants.GetEngineTorque(vehicleConstants.GetCrankshaftSpeed(gasPedal));
             var differentialRatio = vehicleConstants.DifferentialRatio;
             var transmissionEfficiency = vehicleConstants.TransmissionEfficiency;

--- a/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
@@ -47,6 +47,12 @@ namespace AutomatedCar.SystemComponents.Powertrain
             return CalculateTractiveForce(gasPedal, wheelDirection, gearRatio);
         }
 
+        public Vector2 GetBrakingForce(float brakePedal, Vector2 currentVelocity)
+        {
+            var squareVelocity = currentVelocity * currentVelocity;
+            return brakePedal * vehicleConstants.BrakingConstant * -squareVelocity;
+        }
+
         private Vector2 CalculateTractiveForce(float gasPedal, Vector2 wheelDirection, float gearRatio)
         {
             var engineTorque = vehicleConstants.GetEngineTorque(vehicleConstants.GetCrankshaftSpeed(gasPedal));

--- a/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace AutomatedCar.SystemComponents.Powertrain
 {
-    public class VehicleForces
+    public class VehicleForces : IVehicleForces
     {
         private readonly IVehicleConstants vehicleConstants;
 
@@ -38,7 +38,7 @@ namespace AutomatedCar.SystemComponents.Powertrain
 
         public Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, int gearIdx)
         {
-            if(gearIdx < 0 || vehicleConstants.NumberOfGears <= gearIdx)
+            if (gearIdx < 0 || vehicleConstants.NumberOfGears <= gearIdx)
             {
                 throw new ArgumentException("Gear index is out of bounds.", nameof(gearIdx));
             }

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/VehicleForcesTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/VehicleForcesTests.cs
@@ -16,6 +16,18 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             constants.Setup(C => C.AirDensity).Returns(1.184f);
             constants.Setup(C => C.DragCoefficient).Returns(0.280f);
             constants.Setup(C => C.CrossSectionalArea).Returns(2.642f);
+            constants.Setup(C => C.NumberOfGears).Returns(2);
+            constants.Setup(C => C.GearRatios).Returns(new float[] { 1 / 5.25f, 1 / 3.03f });
+            constants.Setup(C => C.ReverseGearRatio).Returns(1 / 4.01f);
+            constants.Setup(C => C.OverallWheelRadius).Returns(1);
+            constants.Setup(C => C.TransmissionEfficiency).Returns(1);
+            constants.Setup(C => C.DifferentialRatio).Returns(1);
+
+            constants.Setup(C => C.GetCrankshaftSpeed(It.IsAny<float>()))
+                .Returns((float p) => p * 6000);
+
+            constants.Setup(C => C.GetEngineTorque(It.IsAny<float>()))
+                .Returns((float rpm) => rpm * 100);
         }
 
         [Fact]
@@ -62,6 +74,88 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             var diff = Math.Abs(-1 - dot);
 
             Assert.True(diff < float.Epsilon);
+        }
+
+        [Fact]
+        public void TractiveForcePointsInTheDirectionOfTheWheels()
+        {
+            var forceCalculator = new VehicleForces(constants.Object);
+            var isReverse = false;
+            var gear = 1;
+            var wheelDirection = new Vector2(0, 1);
+            var gasPedal = 1.0f;
+
+            var force = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gear);
+
+            // NOTE(danielm): dot product of two unit vectors is 1 if the
+            // angle between them is 0 degrees.
+            var dot = Vector2.Dot(Vector2.Normalize(force), wheelDirection);
+            var diff = Math.Abs(1 - dot);
+
+            Assert.True(diff < float.Epsilon);
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        public void TractiveForceIsProportionalToCurrentGear(int gearIdx0, int gearIdx1)
+        {
+            var forceCalculator = new VehicleForces(constants.Object);
+            var isReverse = false;
+            var wheelDirection = new Vector2(0, 1);
+            var gasPedal = 1.0f;
+
+            var force0 = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx0);
+            var force1 = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx1);
+
+            var ratio = force1.Length() / force0.Length();
+            Assert.True(ratio >= 1);
+        }
+
+        [Fact]
+        public void TractiveForcePointsInTheReverseDirectionInReverseGear()
+        {
+            var forceCalculator = new VehicleForces(constants.Object);
+            var isReverse = true;
+            var wheelDirection = new Vector2(0, 1);
+            var gasPedal = 1.0f;
+            int? gearIndex = null;
+
+            var force = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIndex);
+
+            // NOTE(danielm): dot product of two units vectors is -1 if the
+            // angle between them is 180deg.
+            var dot = Vector2.Dot(Vector2.Normalize(force), Vector2.Normalize(wheelDirection));
+            var diff = Math.Abs(-1 - dot);
+
+            Assert.True(diff < float.Epsilon);
+        }
+
+        [Fact]
+        public void GetTractiveForceThrowsWhenGearIndexIsOutOfBounds()
+        {
+            var forceCalculator = new VehicleForces(constants.Object);
+            var isReverse = false;
+            var wheelDirection = new Vector2(0, 1);
+            var gasPedal = 1.0f;
+            var gearIdx = constants.Object.NumberOfGears;
+
+            Assert.Throws<ArgumentException>(
+                () => forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx)
+            );
+        }
+
+        [Fact]
+        public void GetTractiveForceThrowsInDriveStateWhenGearIndexIsNull()
+        {
+            var forceCalculator = new VehicleForces(constants.Object);
+            var isReverse = false;
+            var wheelDirection = new Vector2(0, 1);
+            var gasPedal = 1.0f;
+            int? gearIdx = null;
+
+            Assert.Throws<ArgumentException>(
+                () => forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx)
+            );
         }
     }
 }

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/VehicleForcesTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/VehicleForcesTests.cs
@@ -80,12 +80,11 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         public void TractiveForcePointsInTheDirectionOfTheWheels()
         {
             var forceCalculator = new VehicleForces(constants.Object);
-            var isReverse = false;
             var gear = 1;
             var wheelDirection = new Vector2(0, 1);
             var gasPedal = 1.0f;
 
-            var force = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gear);
+            var force = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, gear);
 
             // NOTE(danielm): dot product of two unit vectors is 1 if the
             // angle between them is 0 degrees.
@@ -100,12 +99,11 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         public void TractiveForceIsProportionalToCurrentGear(int gearIdx0, int gearIdx1)
         {
             var forceCalculator = new VehicleForces(constants.Object);
-            var isReverse = false;
             var wheelDirection = new Vector2(0, 1);
             var gasPedal = 1.0f;
 
-            var force0 = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx0);
-            var force1 = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx1);
+            var force0 = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, gearIdx0);
+            var force1 = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, gearIdx1);
 
             var ratio = force1.Length() / force0.Length();
             Assert.True(ratio >= 1);
@@ -115,12 +113,10 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         public void TractiveForcePointsInTheReverseDirectionInReverseGear()
         {
             var forceCalculator = new VehicleForces(constants.Object);
-            var isReverse = true;
             var wheelDirection = new Vector2(0, 1);
             var gasPedal = 1.0f;
-            int? gearIndex = null;
 
-            var force = forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIndex);
+            var force = forceCalculator.GetTractiveForceInReverse(gasPedal, wheelDirection);
 
             // NOTE(danielm): dot product of two units vectors is -1 if the
             // angle between them is 180deg.
@@ -134,27 +130,25 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         public void GetTractiveForceThrowsWhenGearIndexIsOutOfBounds()
         {
             var forceCalculator = new VehicleForces(constants.Object);
-            var isReverse = false;
             var wheelDirection = new Vector2(0, 1);
             var gasPedal = 1.0f;
             var gearIdx = constants.Object.NumberOfGears;
 
             Assert.Throws<ArgumentException>(
-                () => forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx)
+                () => forceCalculator.GetTractiveForce(gasPedal, wheelDirection, gearIdx)
             );
         }
 
         [Fact]
-        public void GetTractiveForceThrowsInDriveStateWhenGearIndexIsNull()
+        public void GetTractiveForceThrowsWhenGearIndexIsLessThanZero()
         {
             var forceCalculator = new VehicleForces(constants.Object);
-            var isReverse = false;
             var wheelDirection = new Vector2(0, 1);
             var gasPedal = 1.0f;
-            int? gearIdx = null;
+            var gearIdx = -1;
 
             Assert.Throws<ArgumentException>(
-                () => forceCalculator.GetTractiveForce(gasPedal, wheelDirection, isReverse, gearIdx)
+                () => forceCalculator.GetTractiveForce(gasPedal, wheelDirection, gearIdx)
             );
         }
     }


### PR DESCRIPTION
Implementálva lett a vonó -és a fékezési erők kiszámítása, valamint létrehozásra került az `IVehicleForces` interfész, hogy majd a priority checker működését lehessen tesztelni.

- Vonóerő (task #22)
  - Erő kiszámítása
  - Tesztelni, hogy iránya párhuzamos az elülső kerekek által mutatott iránnyal
  - Tesztelni, hogy az erő növekszik ahogy egyre nagyobb gear-be váltunk úgy, hogy az RPM fix
  - Tesztelni, hogy Reverse állásban az erő az ellentétes irányba mutat
- Fékezési erő (task #23)
  - Erő kiszámítása
  - Tesztelni, hogy nagysága arányos a fékpedál állásával
  - Tesztelni, hogy iránya ellentétes a haladási iránnyal
