### PR TITLE
Vizualiáció során használt kamera

### DIFF
--- a/src/AutomatedCar/Models/IRenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/IRenderableWorldObject.cs
@@ -1,4 +1,6 @@
-﻿namespace AutomatedCar.Models
+﻿using System.Windows;
+
+namespace AutomatedCar.Models
 {
     public interface IRenderableWorldObject
     {
@@ -8,5 +10,6 @@
         int X { get; set; }
         int Y { get; set; }
         int ZIndex { get; set; }
+        Rect Boundary { get; }
     }
 }

--- a/src/AutomatedCar/Models/IRenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/IRenderableWorldObject.cs
@@ -1,0 +1,12 @@
+﻿namespace AutomatedCar.Models
+{
+    public interface IRenderableWorldObject
+    {
+        string Filename { get; set; }
+        int Height { get; set; }
+        int Width { get; set; }
+        int X { get; set; }
+        int Y { get; set; }
+        int ZIndex { get; set; }
+    }
+}

--- a/src/AutomatedCar/Models/IRenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/IRenderableWorldObject.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows;
-
-namespace AutomatedCar.Models
+﻿namespace AutomatedCar.Models
 {
     public interface IRenderableWorldObject
     {

--- a/src/AutomatedCar/Models/IRenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/IRenderableWorldObject.cs
@@ -10,6 +10,5 @@ namespace AutomatedCar.Models
         int X { get; set; }
         int Y { get; set; }
         int ZIndex { get; set; }
-        Rect Boundary { get; }
     }
 }

--- a/src/AutomatedCar/Models/RenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/RenderableWorldObject.cs
@@ -3,6 +3,7 @@ using BaseModel.WorldObjects;
 namespace AutomatedCar.Models
 {
     using ReactiveUI;
+    using System.Windows;
 
     public abstract class RenderableWorldObject : ReactiveObject, IRenderableWorldObject
     {
@@ -36,6 +37,8 @@ namespace AutomatedCar.Models
             get => this._y;
             set => this.RaiseAndSetIfChanged(ref this._y, value);
         }
+
+        public Rect Boundary => new Rect(X, Y, Width, Height);
 
         public string Filename { get; set; }
     }

--- a/src/AutomatedCar/Models/RenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/RenderableWorldObject.cs
@@ -38,8 +38,6 @@ namespace AutomatedCar.Models
             set => this.RaiseAndSetIfChanged(ref this._y, value);
         }
 
-        public Rect Boundary => new Rect(X, Y, Width, Height);
-
         public string Filename { get; set; }
     }
 }

--- a/src/AutomatedCar/Models/RenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/RenderableWorldObject.cs
@@ -3,7 +3,6 @@ using BaseModel.WorldObjects;
 namespace AutomatedCar.Models
 {
     using ReactiveUI;
-    using System.Windows;
 
     public abstract class RenderableWorldObject : ReactiveObject, IRenderableWorldObject
     {

--- a/src/AutomatedCar/Models/RenderableWorldObject.cs
+++ b/src/AutomatedCar/Models/RenderableWorldObject.cs
@@ -4,7 +4,7 @@ namespace AutomatedCar.Models
 {
     using ReactiveUI;
 
-    public abstract class RenderableWorldObject : ReactiveObject
+    public abstract class RenderableWorldObject : ReactiveObject, IRenderableWorldObject
     {
         private int _x;
         private int _y;

--- a/src/AutomatedCar/Visualization/RenderCamera.cs
+++ b/src/AutomatedCar/Visualization/RenderCamera.cs
@@ -39,7 +39,7 @@ namespace AutomatedCar.Visualization
 
         public bool IsVisibleInViewport(IRenderableWorldObject renderable)
         {
-            return ViewportRect.IntersectsWith(renderable.Boundary);
+            return ViewportRect.IntersectsWith(WorldObjectTransformer.GetBoundary(renderable));
         }
 
         public Point TranslateToViewport(double worldX, double worldY)

--- a/src/AutomatedCar/Visualization/RenderCamera.cs
+++ b/src/AutomatedCar/Visualization/RenderCamera.cs
@@ -1,9 +1,5 @@
 ﻿using AutomatedCar.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace AutomatedCar.Visualization
@@ -14,6 +10,8 @@ namespace AutomatedCar.Visualization
         public double TopY { get; set; }
         public double Width { get; set; }
         public double Height { get; set; }
+        public double MiddleX { get; private set; }
+        public double MiddleY { get; private set; }
 
         public Rect ViewportRect => new Rect(LeftX, TopY, Width, Height);
 
@@ -21,6 +19,9 @@ namespace AutomatedCar.Visualization
         {
             LeftX = originX - (Width / 2.0);
             TopY = originY + (Height / 2.0);
+
+            MiddleX = originX;
+            MiddleY = originY;
         }
 
         public List<IRenderableWorldObject> Filter(List<IRenderableWorldObject> renderables)
@@ -39,6 +40,13 @@ namespace AutomatedCar.Visualization
         public bool IsVisibleInViewport(IRenderableWorldObject renderable)
         {
             return ViewportRect.IntersectsWith(renderable.Boundary);
+        }
+
+        public Point TranslateToViewport(double worldX, double worldY)
+        {
+            var x = worldX - LeftX;
+            var y = worldY - TopY;
+            return new Point(x, y);
         }
     }
 }

--- a/src/AutomatedCar/Visualization/RenderCamera.cs
+++ b/src/AutomatedCar/Visualization/RenderCamera.cs
@@ -1,0 +1,44 @@
+﻿using AutomatedCar.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace AutomatedCar.Visualization
+{
+    public class RenderCamera
+    {
+        public double LeftX { get; set; }
+        public double TopY { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+
+        public Rect ViewportRect => new Rect(LeftX, TopY, Width, Height);
+
+        public void UpdateMiddlePoint(double originX, double originY)
+        {
+            LeftX = originX - (Width / 2.0);
+            TopY = originY + (Height / 2.0);
+        }
+
+        public List<IRenderableWorldObject> Filter(List<IRenderableWorldObject> renderables)
+        {
+            var visible = new List<IRenderableWorldObject>();
+
+            foreach (var renderable in renderables)
+            {
+                if (IsVisibleInViewport(renderable))
+                    visible.Add(renderable);
+            }
+
+            return visible;
+        }
+
+        public bool IsVisibleInViewport(IRenderableWorldObject renderable)
+        {
+            return ViewportRect.IntersectsWith(renderable.Boundary);
+        }
+    }
+}

--- a/src/AutomatedCar/Visualization/WorldObjectTransformer.cs
+++ b/src/AutomatedCar/Visualization/WorldObjectTransformer.cs
@@ -1,5 +1,6 @@
 namespace AutomatedCar.Visualization
 {
+    using AutomatedCar.Models;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
@@ -25,6 +26,11 @@ namespace AutomatedCar.Visualization
             }
 
             return cache[filename];
+        }
+
+        internal static Rect GetBoundary(IRenderableWorldObject renderable)
+        {
+            return new Rect(renderable.X, renderable.Y, renderable.Width, renderable.Height);
         }
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>

--- a/src/AutomatedCar/Visualization/WorldRenderer.cs
+++ b/src/AutomatedCar/Visualization/WorldRenderer.cs
@@ -12,6 +12,7 @@ namespace AutomatedCar.Visualization
     {
         public readonly double tickRate = 20;
         private readonly DispatcherTimer renderTimer = new DispatcherTimer();
+        private readonly RenderCamera renderCamera = new RenderCamera();
 
         public World World => World.Instance;
 
@@ -32,14 +33,22 @@ namespace AutomatedCar.Visualization
 
         public WorldRenderer()
         {
-            renderTimer.Interval = TimeSpan.FromMilliseconds(tickRate);
-            renderTimer.Tick += Timer_Tick;
-            renderTimer.Start();
+            Loaded += WorldRenderer_Loaded;
         }
 
         private void Timer_Tick(object sender, EventArgs e)
         {
             InvalidateVisual();
+        }
+
+        private void WorldRenderer_Loaded(object sender, RoutedEventArgs e)
+        {
+            renderTimer.Interval = TimeSpan.FromMilliseconds(tickRate);
+            renderTimer.Tick += Timer_Tick;
+            renderTimer.Start();
+
+            renderCamera.Width = ActualWidth;
+            renderCamera.Height = ActualHeight;
         }
     }
 }

--- a/src/AutomatedCar/Visualization/WorldRenderer.cs
+++ b/src/AutomatedCar/Visualization/WorldRenderer.cs
@@ -1,9 +1,7 @@
 ﻿using AutomatedCar.Models;
 using System;
-using System.IO;
 using System.Windows;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 
 namespace AutomatedCar.Visualization

--- a/test/AutomatedCarTest/AutomatedCarTest.csproj
+++ b/test/AutomatedCarTest/AutomatedCarTest.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
+++ b/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
@@ -1,9 +1,7 @@
 ﻿using AutomatedCar.Models;
 using AutomatedCar.Visualization;
 using Moq;
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Windows;
 using Xunit;
 
@@ -52,6 +50,20 @@ namespace Test.Visualization
         }
 
         [Theory]
+        [InlineData(10, 7, 5, 2)]
+        [InlineData(16, 5, 11, 0)]
+        public void CanTranslateGlobalCoordsToLocals(double x, double y, double expectedViewportX, double expectedViewportY)
+        {
+            camera.LeftX = 5;
+            camera.TopY = 5;
+
+            Point actual = camera.TranslateToViewport(x, y);
+
+            Assert.Equal(expectedViewportX, actual.X);
+            Assert.Equal(expectedViewportY, actual.Y);
+        }
+
+        [Theory]
         [InlineData(5, 5, 10, 10)]
         [InlineData(0, 0, 20, 30)]
         [InlineData(450, 500, 150, 30)]
@@ -84,15 +96,15 @@ namespace Test.Visualization
         private readonly List<IRenderableWorldObject> visibleObjects = new List<IRenderableWorldObject>();
         private readonly List<IRenderableWorldObject> farawayObjects = new List<IRenderableWorldObject>();
 
-        Mock<IRenderableWorldObject> vis1 = new Mock<IRenderableWorldObject>();
-        Mock<IRenderableWorldObject> vis2 = new Mock<IRenderableWorldObject>();
-        Mock<IRenderableWorldObject> vis3 = new Mock<IRenderableWorldObject>();
+        private Mock<IRenderableWorldObject> vis1 = new Mock<IRenderableWorldObject>();
+        private Mock<IRenderableWorldObject> vis2 = new Mock<IRenderableWorldObject>();
+        private Mock<IRenderableWorldObject> vis3 = new Mock<IRenderableWorldObject>();
 
-        Mock<IRenderableWorldObject> far1 = new Mock<IRenderableWorldObject>();
+        private Mock<IRenderableWorldObject> far1 = new Mock<IRenderableWorldObject>();
 
         public RenderCameraTests()
         {
-            camera.Width = 960; 
+            camera.Width = 960;
             camera.Height = 720;
 
             SetupVisibles();

--- a/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
+++ b/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Windows;
 using Xunit;
 
 namespace Test.Visualization
@@ -62,6 +63,7 @@ namespace Test.Visualization
             renderable.Setup(r => r.Y).Returns(y);
             renderable.Setup(r => r.Width).Returns(width);
             renderable.Setup(r => r.Height).Returns(height);
+            renderable.Setup(r => r.Boundary).Returns(GenerateBoundaryFromMoq(renderable.Object));
 
             var result = camera.IsVisibleInViewport(renderable.Object);
             Assert.True(result);
@@ -107,18 +109,23 @@ namespace Test.Visualization
             vis1.Setup(v => v.Y).Returns(50);
             vis1.Setup(v => v.Width).Returns(5);
             vis1.Setup(v => v.Height).Returns(15);
+            vis1.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(vis1.Object));
             visibleObjects.Add(vis1.Object);
+
             vis2 = new Mock<IRenderableWorldObject>();
             vis2.Setup(v => v.X).Returns(100);
             vis2.Setup(v => v.Y).Returns(100);
             vis2.Setup(v => v.Width).Returns(5);
             vis2.Setup(v => v.Height).Returns(15);
+            vis2.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(vis2.Object));
             visibleObjects.Add(vis2.Object);
+
             vis3 = new Mock<IRenderableWorldObject>();
             vis3.Setup(v => v.X).Returns(300);
             vis3.Setup(v => v.Y).Returns(300);
             vis3.Setup(v => v.Width).Returns(5);
             vis3.Setup(v => v.Height).Returns(15);
+            vis3.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(vis3.Object));
             visibleObjects.Add(vis3.Object);
         }
 
@@ -129,7 +136,13 @@ namespace Test.Visualization
             far1.Setup(f => f.Y).Returns(5000);
             far1.Setup(f => f.Width).Returns(5);
             far1.Setup(f => f.Height).Returns(5);
+            far1.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(far1.Object));
             farawayObjects.Add(far1.Object);
+        }
+
+        private Rect GenerateBoundaryFromMoq(IRenderableWorldObject renderable)
+        {
+            return new Rect(renderable.X, renderable.Y, renderable.Width, renderable.Height);
         }
 
         #endregion TestInternal

--- a/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
+++ b/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
@@ -1,0 +1,137 @@
+﻿using AutomatedCar.Models;
+using AutomatedCar.Visualization;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace Test.Visualization
+{
+    public class RenderCameraTests
+    {
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(9, 16, 144)]
+        [InlineData(960, 720, 691200)]
+        public void CalculatesViewportOnTheFly(double cameraWidth, double cameraHeight, double expectedArea)
+        {
+            camera.Width = cameraWidth;
+            camera.Height = cameraHeight;
+
+            var viewport = camera.ViewportRect;
+
+            Assert.Equal(expectedArea, viewport.Width * viewport.Height);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(150, 2500)]
+        [InlineData(-150, 600)]
+        public void CameraPositionOffsetsViewport(double x, double y)
+        {
+            camera.LeftX = x;
+            camera.TopY = y;
+
+            var viewport = camera.ViewportRect;
+
+            Assert.Equal(x, viewport.X);
+            Assert.Equal(y, viewport.Y);
+        }
+
+        [Theory]
+        [InlineData(0, 0, -480, 360)]
+        [InlineData(1500, 1000, 1020, 1360)]
+        public void UpdatingOriginOffsetsTopLeftCoordinates(double originX, double originY, double expectedTopLeftX, double expectedTopLeftY)
+        {
+            camera.UpdateMiddlePoint(originX, originY);
+
+            Assert.Equal(expectedTopLeftX, camera.ViewportRect.X);
+            Assert.Equal(expectedTopLeftY, camera.ViewportRect.Y);
+        }
+
+        [Theory]
+        [InlineData(5, 5, 10, 10)]
+        [InlineData(0, 0, 20, 30)]
+        [InlineData(450, 500, 150, 30)]
+        [InlineData(-500, -1500, 5000, 5000)]
+        public void CameraDetectsIntersectionsCorrectly(int x, int y, int width, int height)
+        {
+            var renderable = new Mock<IRenderableWorldObject>();
+            renderable.Setup(r => r.X).Returns(x);
+            renderable.Setup(r => r.Y).Returns(y);
+            renderable.Setup(r => r.Width).Returns(width);
+            renderable.Setup(r => r.Height).Returns(height);
+
+            var result = camera.IsVisibleInViewport(renderable.Object);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CameraFiltersToVisibleObjects()
+        {
+            var actual = camera.Filter(renderables);
+
+            Assert.Equal(visibleObjects, actual);
+        }
+
+        #region TestInternal
+
+        private readonly RenderCamera camera = new RenderCamera();
+        private readonly List<IRenderableWorldObject> renderables = new List<IRenderableWorldObject>();
+        private readonly List<IRenderableWorldObject> visibleObjects = new List<IRenderableWorldObject>();
+        private readonly List<IRenderableWorldObject> farawayObjects = new List<IRenderableWorldObject>();
+
+        Mock<IRenderableWorldObject> vis1 = new Mock<IRenderableWorldObject>();
+        Mock<IRenderableWorldObject> vis2 = new Mock<IRenderableWorldObject>();
+        Mock<IRenderableWorldObject> vis3 = new Mock<IRenderableWorldObject>();
+
+        Mock<IRenderableWorldObject> far1 = new Mock<IRenderableWorldObject>();
+
+        public RenderCameraTests()
+        {
+            camera.Width = 960; 
+            camera.Height = 720;
+
+            SetupVisibles();
+            SetupFaraways();
+
+            renderables.AddRange(visibleObjects);
+            renderables.AddRange(farawayObjects);
+        }
+
+        private void SetupVisibles()
+        {
+            vis1 = new Mock<IRenderableWorldObject>();
+            vis1.Setup(v => v.X).Returns(50);
+            vis1.Setup(v => v.Y).Returns(50);
+            vis1.Setup(v => v.Width).Returns(5);
+            vis1.Setup(v => v.Height).Returns(15);
+            visibleObjects.Add(vis1.Object);
+            vis2 = new Mock<IRenderableWorldObject>();
+            vis2.Setup(v => v.X).Returns(100);
+            vis2.Setup(v => v.Y).Returns(100);
+            vis2.Setup(v => v.Width).Returns(5);
+            vis2.Setup(v => v.Height).Returns(15);
+            visibleObjects.Add(vis2.Object);
+            vis3 = new Mock<IRenderableWorldObject>();
+            vis3.Setup(v => v.X).Returns(300);
+            vis3.Setup(v => v.Y).Returns(300);
+            vis3.Setup(v => v.Width).Returns(5);
+            vis3.Setup(v => v.Height).Returns(15);
+            visibleObjects.Add(vis3.Object);
+        }
+
+        private void SetupFaraways()
+        {
+            far1 = new Mock<IRenderableWorldObject>();
+            far1.Setup(f => f.X).Returns(6000);
+            far1.Setup(f => f.Y).Returns(5000);
+            far1.Setup(f => f.Width).Returns(5);
+            far1.Setup(f => f.Height).Returns(5);
+            farawayObjects.Add(far1.Object);
+        }
+
+        #endregion TestInternal
+    }
+}

--- a/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
+++ b/test/AutomatedCarTest/Visualization/RenderCameraTests.cs
@@ -75,7 +75,6 @@ namespace Test.Visualization
             renderable.Setup(r => r.Y).Returns(y);
             renderable.Setup(r => r.Width).Returns(width);
             renderable.Setup(r => r.Height).Returns(height);
-            renderable.Setup(r => r.Boundary).Returns(GenerateBoundaryFromMoq(renderable.Object));
 
             var result = camera.IsVisibleInViewport(renderable.Object);
             Assert.True(result);
@@ -121,7 +120,6 @@ namespace Test.Visualization
             vis1.Setup(v => v.Y).Returns(50);
             vis1.Setup(v => v.Width).Returns(5);
             vis1.Setup(v => v.Height).Returns(15);
-            vis1.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(vis1.Object));
             visibleObjects.Add(vis1.Object);
 
             vis2 = new Mock<IRenderableWorldObject>();
@@ -129,7 +127,6 @@ namespace Test.Visualization
             vis2.Setup(v => v.Y).Returns(100);
             vis2.Setup(v => v.Width).Returns(5);
             vis2.Setup(v => v.Height).Returns(15);
-            vis2.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(vis2.Object));
             visibleObjects.Add(vis2.Object);
 
             vis3 = new Mock<IRenderableWorldObject>();
@@ -137,7 +134,6 @@ namespace Test.Visualization
             vis3.Setup(v => v.Y).Returns(300);
             vis3.Setup(v => v.Width).Returns(5);
             vis3.Setup(v => v.Height).Returns(15);
-            vis3.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(vis3.Object));
             visibleObjects.Add(vis3.Object);
         }
 
@@ -148,13 +144,7 @@ namespace Test.Visualization
             far1.Setup(f => f.Y).Returns(5000);
             far1.Setup(f => f.Width).Returns(5);
             far1.Setup(f => f.Height).Returns(5);
-            far1.Setup(v => v.Boundary).Returns(GenerateBoundaryFromMoq(far1.Object));
             farawayObjects.Add(far1.Object);
-        }
-
-        private Rect GenerateBoundaryFromMoq(IRenderableWorldObject renderable)
-        {
-            return new Rect(renderable.X, renderable.Y, renderable.Width, renderable.Height);
         }
 
         #endregion TestInternal


### PR DESCRIPTION
Resolves #41 
Létre lett hozva egy kamera osztály, amely fő feladata szűrni hogy mik azokat a renderable dolgok amik jelenleg viewporton belül esnek. Mozgatható, átméretezhető dinamikusan. A teszteléshez szükséges volt a RenderableWorldObject osztályból egy interface-t kimeríteni, emellett ez kiegészíteni egy boundary box propertyvel. A kamera emellett tud globális koordinátákat viewporton belüli koordinátákká alakítani.