### PR TITLE
A1 sprint1 car control

### DIFF
--- a/src/AutomatedCar/MainWindow.xaml.cs
+++ b/src/AutomatedCar/MainWindow.xaml.cs
@@ -88,7 +88,7 @@ namespace AutomatedCar
             BindACCFeatures(dashBoardViewModel);
             BindParkingPilotAndLaneKeepingFeatures(dashBoardViewModel);
             BindDebugFeatures();
-            BindCarControl(dashBoardViewModel);
+            BindCarControls(dashBoardViewModel);
         }
 
         private void BindParkingPilotAndLaneKeepingFeatures(DashboardViewModel dashBoardViewModel)
@@ -113,7 +113,7 @@ namespace AutomatedCar
             keyboardHandler.PressableKeys.Add(new PressableKey(Key.RightCtrl, () => dashBoardViewModel.ToggleACC()));
         }
 
-        private void BindCarControl(DashboardViewModel dashBoardViewModel)
+        private void BindCarControls(DashboardViewModel dashBoardViewModel)
         {
             keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Up,
                 (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.GasPedalViewModel.Value + (duration * 100), 100),

--- a/src/AutomatedCar/MainWindow.xaml.cs
+++ b/src/AutomatedCar/MainWindow.xaml.cs
@@ -115,10 +115,18 @@ namespace AutomatedCar
 
         private void BindCarControl(DashboardViewModel dashBoardViewModel)
         {
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Up, (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.GasPedalViewModel.Value + (duration * 100), 100), (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Max(dashBoardViewModel.GasPedalViewModel.Value - (duration * 100), 0)));
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Down, (duration) => dashBoardViewModel.BreakPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.BreakPedalViewModel.Value + (duration * 200), 100), (duration) => dashBoardViewModel.BreakPedalViewModel.Value = (int)Math.Max(dashBoardViewModel.BreakPedalViewModel.Value - (duration * 200), 0)));
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Left, (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Max(dashBoardViewModel.SteeringWheelViewModel.Value - (duration * 100), -100), (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Min(dashBoardViewModel.SteeringWheelViewModel.Value + (duration * 100), 0)));
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Right, (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Min(dashBoardViewModel.SteeringWheelViewModel.Value + (duration * 100), 100), (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Max(dashBoardViewModel.SteeringWheelViewModel.Value - (duration * 100), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Up,
+                (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.GasPedalViewModel.Value + (duration * 100), 100),
+                (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Max(dashBoardViewModel.GasPedalViewModel.Value - (duration * 100), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Down,
+                (duration) => dashBoardViewModel.BreakPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.BreakPedalViewModel.Value + (duration * 200), 100),
+                (duration) => dashBoardViewModel.BreakPedalViewModel.Value = (int)Math.Max(dashBoardViewModel.BreakPedalViewModel.Value - (duration * 200), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Left,
+                (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Max(dashBoardViewModel.SteeringWheelViewModel.Value - (duration * 100), -100),
+                (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Min(dashBoardViewModel.SteeringWheelViewModel.Value + (duration * 100), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Right,
+                (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Min(dashBoardViewModel.SteeringWheelViewModel.Value + (duration * 100), 100),
+                (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Max(dashBoardViewModel.SteeringWheelViewModel.Value - (duration * 100), 0)));
         }
 
         private void onKeyDown(object sender, KeyEventArgs e)

--- a/src/AutomatedCar/MainWindow.xaml.cs
+++ b/src/AutomatedCar/MainWindow.xaml.cs
@@ -40,11 +40,6 @@ namespace AutomatedCar
             keyboardHandler = new KeyboardHandler(tickInterval);
             BindKeysForDashboardFunctions(dashBoardViewModel);
 
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Left, (duration) => World.Instance.ControlledCar.X -= 5, null));
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Right, (duration) => World.Instance.ControlledCar.X += 5, null));
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Up, (duration) => World.Instance.ControlledCar.Y -= 5, null));
-            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Down, (duration) => World.Instance.ControlledCar.Y += 5, null));
-
             timer.Interval = TimeSpan.FromMilliseconds(tickInterval);
             timer.Tick += logic;
 
@@ -93,6 +88,7 @@ namespace AutomatedCar
             BindACCFeatures(dashBoardViewModel);
             BindParkingPilotAndLaneKeepingFeatures(dashBoardViewModel);
             BindDebugFeatures();
+            BindCarControl(dashBoardViewModel);
         }
 
         private void BindParkingPilotAndLaneKeepingFeatures(DashboardViewModel dashBoardViewModel)
@@ -115,6 +111,14 @@ namespace AutomatedCar
             keyboardHandler.PressableKeys.Add(new PressableKey(Key.Subtract, () => dashBoardViewModel.DecreaseACCDesiredSpeed()));
             keyboardHandler.PressableKeys.Add(new PressableKey(Key.T, () => dashBoardViewModel.SetToNextACCDesiredDistance()));
             keyboardHandler.PressableKeys.Add(new PressableKey(Key.RightCtrl, () => dashBoardViewModel.ToggleACC()));
+        }
+
+        private void BindCarControl(DashboardViewModel dashBoardViewModel)
+        {
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Up, (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.GasPedalViewModel.Value + (duration * 100), 100), (duration) => dashBoardViewModel.GasPedalViewModel.Value = (int)Math.Max(dashBoardViewModel.GasPedalViewModel.Value - (duration * 100), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Down, (duration) => dashBoardViewModel.BreakPedalViewModel.Value = (int)Math.Min(dashBoardViewModel.BreakPedalViewModel.Value + (duration * 200), 100), (duration) => dashBoardViewModel.BreakPedalViewModel.Value = (int)Math.Max(dashBoardViewModel.BreakPedalViewModel.Value - (duration * 200), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Left, (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Max(dashBoardViewModel.SteeringWheelViewModel.Value - (duration * 100), -100), (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Min(dashBoardViewModel.SteeringWheelViewModel.Value + (duration * 100), 0)));
+            keyboardHandler.HoldableKeys.Add(new HoldableKey(Key.Right, (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Min(dashBoardViewModel.SteeringWheelViewModel.Value + (duration * 100), 100), (duration) => dashBoardViewModel.SteeringWheelViewModel.Value = (int)Math.Max(dashBoardViewModel.SteeringWheelViewModel.Value - (duration * 100), 0)));
         }
 
         private void onKeyDown(object sender, KeyEventArgs e)

--- a/src/AutomatedCar/ViewModels/DashboardViewModel.cs
+++ b/src/AutomatedCar/ViewModels/DashboardViewModel.cs
@@ -33,9 +33,7 @@ namespace AutomatedCar.ViewModels
             this.RpmGaugeViewModel.SetValue(3000);
                      
             this.BreakPedalViewModel = new BreakPedalViewModel();
-            this.BreakPedalViewModel.Value = 75;
             this.GasPedalViewModel = new GasPedalViewModel();
-            this.GasPedalViewModel.Value = 50;
             this.TransmissionViewModel.CurrentGear = Gear.P;
             this.TransmissionViewModel.Caption = $"Gear: {this.TransmissionViewModel.CurrentGear}";
 

--- a/src/AutomatedCar/ViewModels/DashboardViewModel.cs
+++ b/src/AutomatedCar/ViewModels/DashboardViewModel.cs
@@ -18,6 +18,7 @@ namespace AutomatedCar.ViewModels
         private LaneKeepingAndParkingPilotViewModel _laneKeepingAndParkingPilotViewModel;
         private LastSignViewModel _lastSignViewModel;
         private CarInfoViewModel _carInfoViewModel;
+        private SteeringWheelViewModel _steeringWheelViewModel;
 
         public DashboardViewModel(AutomatedCar controlledCar)
         {
@@ -47,6 +48,8 @@ namespace AutomatedCar.ViewModels
             this.CarInfoViewModel.SteeringWheelAngle = 25;
             this.CarInfoViewModel.X = 350;
             this.CarInfoViewModel.Y = 500;
+
+            this.SteeringWheelViewModel = new SteeringWheelViewModel();
         }
 
         public AutomatedCar ControlledCar
@@ -119,6 +122,12 @@ namespace AutomatedCar.ViewModels
         {
             get => this._carInfoViewModel;
             set => this.RaiseAndSetIfChanged(ref this._carInfoViewModel, value);
+        }
+
+        public SteeringWheelViewModel SteeringWheelViewModel
+        {
+            get => this._steeringWheelViewModel;
+            set => this.RaiseAndSetIfChanged(ref this._steeringWheelViewModel, value);
         }
 
         public void ToggleRightIndicator() => this.RightTurnSignalViewModel.Toggle();

--- a/src/AutomatedCar/ViewModels/SteeringWheelViewModel.cs
+++ b/src/AutomatedCar/ViewModels/SteeringWheelViewModel.cs
@@ -1,0 +1,27 @@
+﻿using ReactiveUI;
+
+namespace AutomatedCar.ViewModels
+{
+    public class SteeringWheelViewModel : ViewModelBase
+    {
+        private int _value;
+        private string _caption;
+
+        public SteeringWheelViewModel()
+        {
+            this.Caption = "steering wheel";
+        }
+
+        public int Value
+        {
+            get => this._value;
+            set => this.RaiseAndSetIfChanged(ref this._value, value);
+        }
+
+        public string Caption
+        {
+            get => this._caption;
+            set => this.RaiseAndSetIfChanged(ref this._caption, value);
+        }
+    }
+}


### PR DESCRIPTION
Task #90
A pedálok és a kormány értékei fokozatosan nőnek, majd idővel visszaállnak alaphelyzetbe.

Később érdemes lehet a konzisztencia miatt a #82-höz hasonló módon refaktorálni a kódot, mert jelenleg a MainWindow közvetlenül a ViewModel-ek értékeit állítja. Ebben az esetben javaslom, hogy hozzunk létre erre egy új taskot, illetve csináljunk egy interfészt a DashBoard és a MainWindow közti kommunikációra, ami ténylegesen csak a számára szükséges metódusokhoz/függvényekhez ad hozzáférést. Ha így döntünk, szerintem legalább a sprint végét várjuk meg, jelenleg minden jól működik.

Csináltam egy SteeringWheelViewModel-t, ami a kormány állását tárolja %-osan a gáz- és fékpedálhoz hasonlóan. Elvileg ezt az értéket nem kell megjelenítenünk, ezért nem is feltétlenül szükséges neki ViewModel, de az egyszerűség és az átláthatóság kedvéért most így csináltam, illetve mondhatjuk azt is, hogy *ha majd valamikor mégiscsak meg kell jelenítenünk, akkor már ott lesz rá a ViewModel*.