### PR TITLE
Jármű mozgatásával kapcsolatos bugfixek

### DIFF
--- a/src/AutomatedCar/SystemComponents/Powertrain/CarUpdater.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/CarUpdater.cs
@@ -23,39 +23,37 @@ namespace AutomatedCar.SystemComponents.Powertrain
         private PowertrainComponentPacket powertrainComponentPacket;
         private VehicleTransform currentTransform;
         private float currentSteering;
-        private Vector2 currentWheelDirection;
-        private float currentDirection;
-        private float deltaTime = 0.05f;
+        private Vector2 wheelDirection;
+        private DateTime then;
+        private float deltaTime;
         private const float unitsPerMeters = 48f;
+        private readonly float forceMultiplier;
 
-        public CarUpdater(IVirtualFunctionBus virtualFunctionBus, IVehicleForces vehicleForces, IIntegrator integrator, PowertrainComponentPacket powertrainPacket, IVehicleConstants vehicleConstants)
+        private float wheelRotationVelocity = (float)Math.PI / 64;
+
+        public CarUpdater(IVirtualFunctionBus virtualFunctionBus, IVehicleForces vehicleForces, IIntegrator integrator, PowertrainComponentPacket powertrainPacket, IVehicleConstants vehicleConstants, float forceMultiplier)
         {
             this.VirtualFunctionBus = virtualFunctionBus;
             this.VehicleForces = vehicleForces;
             this.Integrator = integrator;
             this.powertrainComponentPacket = powertrainPacket;
             this.VehicleConstants = vehicleConstants;
+            this.forceMultiplier = forceMultiplier;
 
             currentSteering = 0;
-            currentWheelDirection = currentDirection.MakeUnitVectorFromRadians();
-            currentDirection = 0;
+            wheelDirection = Vector2.UnitX;
             priorityChecker = new PriorityChecker();
             transmission = new Transmission() {Gear = Gear.D};
             priorityChecker.virtualFunctionBus = this.VirtualFunctionBus;
             CreateCurrentTransform();
+
+            then = DateTime.Now;
+            deltaTime = 0.005f;
         }
 
         private void CreateCurrentTransform()
         {
             currentTransform = new VehicleTransform(Vector2.Zero, 0, Vector2.Zero, 0);
-        }
-        private void SetCurrentWheelDirection()
-        {
-            currentDirection.MakeUnitVectorFromRadians(out currentWheelDirection.X, out currentWheelDirection.Y);
-        }
-        private void SetCurrentDirection()
-        {
-            currentDirection = currentTransform.AngularDisplacement + currentSteering;
         }
         private void CalculateSteeringAngle()
         {
@@ -76,6 +74,8 @@ namespace AutomatedCar.SystemComponents.Powertrain
             World.Instance.ControlledCar.CurrentSteering = currentSteering;
             World.Instance.ControlledCar.Velocity = worldTransform.Velocity;
             World.Instance.ControlledCar.Speed = (int)(worldTransform.Velocity.Length()*3.6);
+
+            FillTransformationMatrix(World.Instance.ControlledCar, worldTransform.AngularDisplacement);
         }
 
         public void UpdatePacket()
@@ -92,51 +92,103 @@ namespace AutomatedCar.SystemComponents.Powertrain
         public void Calculate()
         {
             CalculateSteeringAngle();
-            SetCurrentDirection();
-            SetCurrentWheelDirection();
-            Integrator.Reset(currentTransform, deltaTime);
+
+            var currentDirection = currentTransform.AngularDisplacement + currentSteering;
+            wheelDirection = currentDirection.MakeUnitVectorFromRadians();
+            var now = DateTime.Now;
+            var deltaTime = (now - then).TotalSeconds;
+            then = now;
+
+            var gasPedal = VirtualFunctionBus.HMIPacket.GasPedal/ 100f;
+            var brakePedal = VirtualFunctionBus.HMIPacket.BrakePedal / 100f;
+
+            Integrator.Reset(currentTransform, (float)deltaTime);
             transmission.Gear = VirtualFunctionBus.HMIPacket.Gear;
             transmission.SetInsideGear((int)(currentTransform.Velocity.Length() * 3.6));
             PacketEnum priority = priorityChecker.AccelerationPriorityCheck();
             if (priority == PacketEnum.AEB)
             {
-                Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetBrakingForce(1f, currentTransform.Velocity));
+                Integrator.AccumulateForce(WheelKind.Front, forceMultiplier * VehicleForces.GetBrakingForce(1f, currentTransform.Velocity));
             }
             else if (priority == PacketEnum.HMI)
             {
                 if (transmission.Gear != Gear.R)
                 {
-                    Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetBrakingForce(VirtualFunctionBus.HMIPacket.BrakePedal / 100f, currentTransform.Velocity));
+                    Integrator.AccumulateForce(WheelKind.Front, forceMultiplier * VehicleForces.GetBrakingForce(brakePedal, currentTransform.Velocity));
                     if (transmission.Gear == Gear.D)
                     {
-                        Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetTractiveForce(VirtualFunctionBus.HMIPacket.GasPedal / 100f, currentWheelDirection, transmission.InsideGear));
+                        Integrator.AccumulateForce(WheelKind.Front, forceMultiplier * VehicleForces.GetTractiveForce(gasPedal, wheelDirection, transmission.InsideGear));
                     }
                 }
                 else
                 {
-                    Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetBrakingForce(VirtualFunctionBus.HMIPacket.BrakePedal / 100f, currentTransform.Velocity));
-                    Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetTractiveForceInReverse(VirtualFunctionBus.HMIPacket.GasPedal / 100f, currentWheelDirection));
+                    Integrator.AccumulateForce(WheelKind.Front, 8 * VehicleForces.GetBrakingForce(brakePedal, currentTransform.Velocity));
+                    Integrator.AccumulateForce(WheelKind.Front, 8 * VehicleForces.GetTractiveForceInReverse(gasPedal, wheelDirection));
                 }
-                 
             }
             else if (priority == PacketEnum.ACC || priority == PacketEnum.PP)
             {
             }
-            Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetDragForce(currentTransform.Velocity));
-            Integrator.AccumulateForce(WheelKind.Back, VehicleForces.GetDragForce(currentTransform.Velocity));
-            Integrator.AccumulateForce(WheelKind.Front, VehicleForces.GetWheelDirectionHackForce(currentWheelDirection, currentTransform.Velocity));
-            Integrator.AccumulateForce(WheelKind.Back, VehicleForces.GetWheelDirectionHackForce(currentWheelDirection, currentTransform.Velocity));
+            Integrator.AccumulateForce(WheelKind.Front, forceMultiplier * VehicleForces.GetDragForce(currentTransform.Velocity));
+            Integrator.AccumulateForce(WheelKind.Back, forceMultiplier * VehicleForces.GetDragForce(currentTransform.Velocity));
         }
+
         public void SetCurrentTransform()
         {
             currentTransform = Integrator.NextVehicleTransform;
+
+            // HACK: cap vehicle speed at 100m/s to prevent blow-up
+            if(currentTransform.Velocity.Length() > 100)
+            {
+                var fixedVelocity = 100 * Vector2.Normalize(currentTransform.Velocity);
+                currentTransform = currentTransform with { Velocity = fixedVelocity };
+            }
+
+            currentTransform = MakeCarRotateTowardsWheelDirection(currentTransform);
+        }
+
+        private VehicleTransform MakeCarRotateTowardsWheelDirection(VehicleTransform original)
+        {
+            var w = Vector2.Normalize(wheelDirection);
+            var v0_len = original.Velocity.Length();
+
+            if(v0_len < 0.01f)
+            {
+                return original;
+            }
+
+            var v0_normalized = original.Velocity / v0_len;
+            var d = Vector2.Dot(v0_normalized, w);
+            d = Math.Clamp(d, -1, 1);
+            var theta = (float)Math.Acos(d);
+            if(theta < 0.01f)
+            {
+                return original;
+            }
+            var alpha = Math.Min(theta, deltaTime * wheelRotationVelocity);
+            var t = alpha / theta;
+            Console.WriteLine($"theta: {theta} alpha: {alpha}");
+            var v1_normalized = t * w + (1f - t) * v0_normalized;
+            var v1 = v0_len * v1_normalized;
+            return original with { Velocity = v1 };
         }
 
         private VehicleTransform ConvertTransformToWorldSpace(VehicleTransform original)
         {
-            var worldPosition = original.Position / 48f;
-            var worldHeading = (float)(original.AngularDisplacement - Math.PI / 2).NormalizeRadians();
+            var worldPosition = 48 * original.Position;
+            var worldHeading = (float)(original.AngularDisplacement + Math.PI / 2).NormalizeRadians();
             return original with { Position = worldPosition, AngularDisplacement = worldHeading };
+        }
+
+        private void FillTransformationMatrix(RenderableWorldObject obj, float angle)
+        {
+            var sin = (float)Math.Sin(angle);
+            var cos = (float)Math.Cos(angle);
+
+            obj.M11 = cos;
+            obj.M12 = sin;
+            obj.M21 = -sin;
+            obj.M22 = -cos;
         }
     }
 }

--- a/src/AutomatedCar/SystemComponents/Powertrain/IIntegrator.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/IIntegrator.cs
@@ -1,11 +1,12 @@
-﻿using System.Numerics;
+﻿using AutomatedCar.Models.Enums;
+using System.Numerics;
 
 namespace AutomatedCar.SystemComponents.Powertrain
 {
     public interface IIntegrator
     {
         VehicleTransform NextVehicleTransform { get; }
-        void Reset(VehicleTransform vehicleTransform, float deltaTime);
+        void Reset(VehicleTransform vehicleTransform, float deltaTime, Gear currentGear);
         void AccumulateForce(WheelKind wheel, Vector2 force);
     }
 }

--- a/src/AutomatedCar/SystemComponents/Powertrain/IVehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/IVehicleForces.cs
@@ -7,7 +7,6 @@ namespace AutomatedCar.SystemComponents.Powertrain
         Vector2 GetDragForce(Vector2 velocity);
         Vector2 GetTractiveForce(float gasPedal, Vector2 wheelDirection, int gearIdx);
         Vector2 GetTractiveForceInReverse(float gasPedal, Vector2 wheelDirection);
-        Vector2 GetWheelDirectionHackForce(Vector2 wheelDirection, Vector2 velocity);
         Vector2 GetBrakingForce(float brakePedal, Vector2 currentVelocity);
     }
 }

--- a/src/AutomatedCar/SystemComponents/Powertrain/MathExtensions.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/MathExtensions.cs
@@ -10,6 +10,11 @@ namespace AutomatedCar.SystemComponents.Powertrain
             return new Vector2((float)Math.Cos(radians), (float)Math.Sin(radians));
         }
 
+        public static Vector2 MakeUnitVectorFromRadians(this double radians)
+        {
+            return new Vector2((float)Math.Cos(radians), (float)Math.Sin(radians));
+        }
+
         public static float RadiansToDegrees(this float radians)
         {
             return (float)(radians / Math.PI * 180);

--- a/src/AutomatedCar/SystemComponents/Powertrain/ParticleIntegrator.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/ParticleIntegrator.cs
@@ -9,18 +9,21 @@ namespace AutomatedCar.SystemComponents.Powertrain
         private readonly Vector2 velocity;
         private readonly float mass;
         private readonly float deltaTime;
+        private readonly WheelKind wheelKind;
 
         public (Vector2 Position, Vector2 Velocity) NextState => CalculateNextState();
         public float Mass { get => mass; }
         public Vector2 AccumulatedForce { get => forceAccumulator; }
+        public WheelKind WheelKind { get => wheelKind; }
 
-        public ParticleIntegrator(Vector2 position, Vector2 velocity, float mass, float deltaTime)
+        public ParticleIntegrator(Vector2 position, Vector2 velocity, float mass, float deltaTime, WheelKind wheelKind)
         {
             this.forceAccumulator = Vector2.Zero;
             this.position = position;
             this.velocity = velocity;
             this.mass = mass;
             this.deltaTime = deltaTime;
+            this.wheelKind = wheelKind;
         }
 
         public void AccumulateForce(Vector2 force)

--- a/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/PowertrainComponent.cs
@@ -24,7 +24,8 @@ namespace AutomatedCar.SystemComponents.Powertrain
             this.VehicleForces = vehicleForces;
             this.VehicleConstants = vehicleConstants;
             this.Integrator = integrator;
-            this.CarUpdater = new CarUpdater(this.virtualFunctionBus, this.VehicleForces, this.Integrator, powertrainPacket, this.VehicleConstants);
+            var forceMultiplier = 8.0f;
+            this.CarUpdater = new CarUpdater(this.virtualFunctionBus, this.VehicleForces, this.Integrator, powertrainPacket, this.VehicleConstants, forceMultiplier);
         }
 
         public override void Process()

--- a/src/AutomatedCar/SystemComponents/Powertrain/ReverseMovement.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/ReverseMovement.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Numerics;
+
+namespace AutomatedCar.SystemComponents.Powertrain
+{
+    public class ReverseMovement
+    {
+        private float deltaTime;
+        private VehicleTransform transform;
+
+        public float Braking { get; set; }
+        public float Accelerator { get; set; }
+        public Vector2 SteeringWheel { get; set; }
+        public VehicleTransform NextTransform { get => CalculateNextTransform(); }
+
+        public void Reset(VehicleTransform currentTransform, float deltaTime)
+        {
+            this.transform = currentTransform;
+            this.deltaTime = deltaTime;
+        }
+
+        private VehicleTransform CalculateNextTransform()
+        {
+            var movementDirection = Vector2.Normalize(-SteeringWheel);
+            var steeringWheelAngle = Math.Acos(SteeringWheel.X);
+            var rotationDirection = steeringWheelAngle - transform.AngularDisplacement;
+
+            var nextVelocity = (transform.Velocity + Accelerator * deltaTime * movementDirection) * (1f - Braking);
+            var nextPosition = transform.Position + deltaTime * nextVelocity;
+
+            var nextOrientation = transform.AngularDisplacement;
+            if (nextVelocity.Length() > 0)
+            {
+                nextOrientation = (float)(transform.AngularDisplacement + deltaTime * rotationDirection);
+            }
+
+            return new VehicleTransform(nextPosition, nextOrientation, nextVelocity, 0);
+        }
+    }
+}

--- a/src/AutomatedCar/SystemComponents/Powertrain/ReverseMovement.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/ReverseMovement.cs
@@ -25,13 +25,13 @@ namespace AutomatedCar.SystemComponents.Powertrain
             var steeringWheelAngle = Math.Acos(SteeringWheel.X);
             var rotationDirection = steeringWheelAngle - transform.AngularDisplacement;
 
-            var nextVelocity = (transform.Velocity + Accelerator * deltaTime * movementDirection) * (1f - Braking);
-            var nextPosition = transform.Position + deltaTime * nextVelocity;
+            var nextVelocity = (transform.Velocity + (Accelerator * deltaTime * movementDirection)) * (1f - Braking);
+            var nextPosition = transform.Position + (deltaTime * nextVelocity);
 
             var nextOrientation = transform.AngularDisplacement;
             if (nextVelocity.Length() > 0)
             {
-                nextOrientation = (float)(transform.AngularDisplacement + deltaTime * rotationDirection);
+                nextOrientation = (float)(transform.AngularDisplacement + (deltaTime * rotationDirection));
             }
 
             return new VehicleTransform(nextPosition, nextOrientation, nextVelocity, 0);

--- a/src/AutomatedCar/SystemComponents/Powertrain/Transmission.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/Transmission.cs
@@ -11,7 +11,7 @@ namespace AutomatedCar.SystemComponents.Powertrain
     {
         public readonly (int minSpeed, int maxSpeed, int gear)[] DriveSpeedGearMapping = new (int, int, int)[]
         {
-            (0, 10, 0),
+            (int.MinValue, 10, 0),
             (10, 15, 1),
             (15, 20, 2),
             (20, 30, 3),

--- a/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
+++ b/src/AutomatedCar/SystemComponents/Powertrain/VehicleForces.cs
@@ -53,16 +53,6 @@ namespace AutomatedCar.SystemComponents.Powertrain
             return brakePedal * vehicleConstants.BrakingConstant * -squareVelocity;
         }
 
-        public Vector2 GetWheelDirectionHackForce(Vector2 wheelDirection, Vector2 velocity)
-        {
-            // Project velocity into wheelDirection
-            var proj = Vector2.Dot(velocity, wheelDirection) * wheelDirection;
-            // Compute the vector component of velocity orthogonal to wheelDirection
-            var velocityOrthogonal = velocity - proj;
-
-            return velocityOrthogonal.Length() * velocityOrthogonal;
-        }
-
         private Vector2 CalculateTractiveForce(float gasPedal, Vector2 wheelDirection, float gearRatio)
         {
             var engineTorque = vehicleConstants.GetEngineTorque(vehicleConstants.GetCrankshaftSpeed(gasPedal));

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/CarUpdaterTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/CarUpdaterTests.cs
@@ -128,7 +128,7 @@ namespace Test.SystemComponents.Powertrain
             carUpdater.SetCurrentTransform();
             carUpdater.Calculate();
 
-            mockIntegrator.Verify(m => m.Reset(vehicleTransform, It.IsAny<float>()), Times.Once);
+            mockIntegrator.Verify(m => m.Reset(vehicleTransform, It.IsAny<float>(), Gear.D), Times.Once);
         }
 
         [Fact]

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/IntegratorTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/IntegratorTests.cs
@@ -1,4 +1,5 @@
-﻿using AutomatedCar.SystemComponents.Powertrain;
+﻿using AutomatedCar.Models.Enums;
+using AutomatedCar.SystemComponents.Powertrain;
 using Moq;
 using System.Numerics;
 using Xunit;
@@ -21,7 +22,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             var initialTransform = new VehicleTransform(Vector2.Zero, 0, Vector2.Zero, 0);
             var integrator = new Integrator(constants.Object);
 
-            integrator.Reset(initialTransform, 0f);
+            integrator.Reset(initialTransform, 0f, Gear.D);
 
             var nextTransform = integrator.NextVehicleTransform;
 
@@ -35,7 +36,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             var integrator = new Integrator(constants.Object);
             var deltaTime = 0.1f;
 
-            integrator.Reset(initialTransform, deltaTime);
+            integrator.Reset(initialTransform, deltaTime, Gear.D);
             integrator.AccumulateForce(WheelKind.Front, Vector2.UnitX);
             integrator.AccumulateForce(WheelKind.Back, Vector2.UnitX);
             var nextTransform = integrator.NextVehicleTransform;
@@ -50,7 +51,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             var integrator = new Integrator(constants.Object);
             var deltaTime = 0.1f;
 
-            integrator.Reset(initialTransform, deltaTime);
+            integrator.Reset(initialTransform, deltaTime, Gear.D);
             integrator.AccumulateForce(WheelKind.Front, -initialTransform.Velocity);
             integrator.AccumulateForce(WheelKind.Back, -initialTransform.Velocity);
             var nextTransform = integrator.NextVehicleTransform;
@@ -77,7 +78,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             var integrator = new Integrator(constants.Object);
             var deltaTime = 0.1f;
 
-            integrator.Reset(initialTransform, deltaTime);
+            integrator.Reset(initialTransform, deltaTime, Gear.D);
             integrator.AccumulateForce(WheelKind.Front, +10 * Vector2.UnitY);
             integrator.AccumulateForce(WheelKind.Back, -10 * Vector2.UnitY);
             var nextTransform = integrator.NextVehicleTransform;
@@ -92,7 +93,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
             var integrator = new Integrator(constants.Object);
             var deltaTime = 0.01f;
 
-            integrator.Reset(initialTransform, deltaTime);
+            integrator.Reset(initialTransform, deltaTime, Gear.D);
             integrator.AccumulateForce(WheelKind.Front, 10 * new Vector2(1, 2));
             var nextTransform = integrator.NextVehicleTransform;
 

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/ParticleIntegratorTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/ParticleIntegratorTests.cs
@@ -14,7 +14,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         [Fact]
         public void ForceSumming()
         {
-            var integrator = new ParticleIntegrator(Vector2.Zero, Vector2.Zero, 0, 0);
+            var integrator = new ParticleIntegrator(Vector2.Zero, Vector2.Zero, 0, 0, WheelKind.Front);
 
             var force0 = new Vector2(7, -5);
             var force1 = new Vector2(-3, 11);
@@ -32,7 +32,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         public void MassProperty()
         {
             var massInit = 100f;
-            var integrator = new ParticleIntegrator(Vector2.Zero, Vector2.Zero, massInit, 0);
+            var integrator = new ParticleIntegrator(Vector2.Zero, Vector2.Zero, massInit, 0, WheelKind.Front);
 
             var mass = integrator.Mass;
 
@@ -48,7 +48,7 @@ namespace AutomatedCarTest.SystemComponents.Powertrain
         [MemberData(nameof(integrationTestCases))]
         public void NextStateCalculatedIsCorrect(Vector2 initialPosition, Vector2 initialVelocity, float mass, float deltaTime, Vector2 netForce, Vector2 expectedPosition, Vector2 expectedVelocity)
         {
-            var integrator = new ParticleIntegrator(initialPosition, initialVelocity, mass, deltaTime);
+            var integrator = new ParticleIntegrator(initialPosition, initialVelocity, mass, deltaTime, WheelKind.Front);
 
             integrator.AccumulateForce(netForce);
             var (nextPosition, nextVelocity) = integrator.NextState;

--- a/test/AutomatedCarTest/SystemComponents/Powertrain/ReverseMovementTests.cs
+++ b/test/AutomatedCarTest/SystemComponents/Powertrain/ReverseMovementTests.cs
@@ -1,0 +1,100 @@
+﻿using AutomatedCar.SystemComponents.Powertrain;
+using System;
+using System.Numerics;
+using NUnit.Framework;
+
+namespace AutomatedCarTest.SystemComponents.Powertrain
+{
+    public class ReverseMovementTests
+    {
+        private readonly ReverseMovement reverseMovement = new ReverseMovement();
+
+        [Test]
+        public void IdentityProperty()
+        {
+            var deltaTime = 1f;
+            var initPosition = Vector2.Zero;
+            var initOrientation = 0f;
+            var initVelocity = Vector2.Zero;
+            var initAngularVelocity = 0f;
+            var transform = new VehicleTransform(initPosition, initOrientation, initVelocity, initAngularVelocity);
+
+            reverseMovement.Reset(transform, deltaTime);
+            reverseMovement.Accelerator = 0f;
+            reverseMovement.Braking = 0f;
+            reverseMovement.SteeringWheel = initOrientation.MakeUnitVectorFromRadians();
+
+            var nextTransform = reverseMovement.NextTransform;
+
+            Assert.AreEqual(transform, nextTransform);
+        }
+
+        [Test]
+        public void MovementDirection()
+        {
+            var deltaTime = 1f;
+            var initPosition = Vector2.Zero;
+            var initOrientation = 0f;
+            var initVelocity = Vector2.Zero;
+            var initAngularVelocity = 0f;
+            var transform = new VehicleTransform(initPosition, initOrientation, initVelocity, initAngularVelocity);
+
+            reverseMovement.Reset(transform, deltaTime);
+            reverseMovement.Accelerator = 1f;
+            reverseMovement.Braking = 0f;
+            reverseMovement.SteeringWheel = initOrientation.MakeUnitVectorFromRadians();
+
+            var nextTransform = reverseMovement.NextTransform;
+
+            var expectedMovementDirection = ((float)(initOrientation - Math.PI)).MakeUnitVectorFromRadians();
+            var movementDirection = Vector2.Normalize(nextTransform.Velocity);
+            var cosineOfAngle = Vector2.Dot(expectedMovementDirection, movementDirection);
+
+            Assert.AreEqual(1f, cosineOfAngle, 0.005f);
+        }
+
+        [Test]
+        public void ChangeOfOrientation()
+        {
+            var deltaTime = 1f;
+            var initPosition = Vector2.Zero;
+            var initOrientation = 0f;
+            var initVelocity = Vector2.Zero;
+            var initAngularVelocity = 0f;
+            var transform = new VehicleTransform(initPosition, initOrientation, initVelocity, initAngularVelocity);
+            var steeringWheelAngle = 45.0;
+
+            reverseMovement.Reset(transform, deltaTime);
+            reverseMovement.Accelerator = 1f;
+            reverseMovement.Braking = 0f;
+            reverseMovement.SteeringWheel = steeringWheelAngle.DegreesToRadians().MakeUnitVectorFromRadians();
+
+            var nextTransform = reverseMovement.NextTransform;
+
+            var changeOfOrientation = nextTransform.AngularDisplacement - transform.AngularDisplacement;
+            // changeOfOrientation and steeringWheelAngle have the same sign, that is
+            // they point in the same direction
+            Assert.GreaterOrEqual(changeOfOrientation * steeringWheelAngle, 0);
+        }
+
+        [Test]
+        public void VelocityIsIntegrated()
+        {
+            var deltaTime = 1f;
+            var initPosition = Vector2.Zero;
+            var initOrientation = 0f;
+            var initVelocity = new Vector2(10, -20);
+            var initAngularVelocity = 0f;
+            var transform = new VehicleTransform(initPosition, initOrientation, initVelocity, initAngularVelocity);
+
+            reverseMovement.Reset(transform, deltaTime);
+            reverseMovement.Accelerator = 0f;
+            reverseMovement.Braking = 0f;
+            reverseMovement.SteeringWheel = Vector2.UnitX;
+
+            var nextTransform = reverseMovement.NextTransform;
+
+            Assert.AreEqual(nextTransform.Position, deltaTime * initVelocity);
+        }
+    }
+}


### PR DESCRIPTION
- Ki lett javítva, hogy az autó túl gyorsan gyorsult
  - Ugyan mi a Powertrain komponensben fix 1/20Hz deltával számoltunk, a VFB valójában olyan gyorsan hívogat meg bennünket, amilyen gyorsan csak lehet
  - A Powertrain ezért mostantól nem bízik meg semmilyen külső modulban vagy konstansban és kiszámítja magának a deltát
- A kormányzás most már oké drive és reverse módban is
- Parking gearben az autó megáll
- Megjelenítés számára most már kitöltjük a transzformációs mátrixot
  - Rossznak látszik, de csak azért, mert a sprite a bal felső sarok körül kerül elforgatásra, nem pedig a közepe körül

User story: #3 